### PR TITLE
Derive trust from observed signals; protect the trust store; wire up a fail-closed gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,31 @@ Riggs uses a **3-window exponential weighted moving average (EWMA)** similar to 
 
 Each turn is scored (0.0–1.0) based on event type: successful tool calls, mode switches, failures, constraint violations.
 
-### Trust-Informed Transitions
+Scores are integrity-protected (see [Trust Integrity](docs/trust-integrity.md)):
+- Authoritative trust state lives in an **append-only, HMAC-chained ledger
+  outside the project tree** — not in the project-local DuckDB store, which is
+  analytics only. Deleting or editing project files never raises trust.
+- Events are tagged **observed** (independently recorded outcomes, e.g. blq
+  exit codes) or **self-reported** (the session's own claims). Self-reported
+  events can hold or lower trust but never raise it.
+- An unknown subject starts **low** (`initial_trust`, default 0.4) and accrues
+  trust from observed evidence. Absent or tampered state reads as low trust —
+  fail closed, never fail open.
+
+### Trust-Informed Transitions and the Gate
 Riggs monitors trust windows and recommends tightening/loosening:
 - t1 < 0.3: Recommend tightening
 - t1 < 0.3 AND t5 < 0.5: Auto-tighten
-- t5 declining 10+ turns: Coach message
-- t1 > 0.9 AND t5 > 0.8 for 20+ turns: Suggest loosening
+- t1 > 0.9 AND t5 > 0.8 held for 20+ consecutive turns: Suggest loosening
 - t15 < 0.5: Flag project config
 
-Recommendations are written to `.kibitzer/state.json`. Riggs never enforces directly — kibitzer controls the decision.
+Recommendations are written to `.kibitzer/state.json` after each ingest for
+kibitzer's mode controller to act on. Capability-expanding decisions
+additionally pass through the **fail-closed trust gate** (`agent-riggs gate`,
+the `RiggsGate` MCP tool, and tool promotions): the gate denies on absent or
+unverifiable trust state, insufficient trust, or recent violations. Mode
+control stays with kibitzer; the gate is the enforcement point riggs itself
+guarantees.
 
 ### Cross-Session Failure Stream
 Riggs ingests turn data from kibitzer and builds a cross-session failure stream. Each failure is categorized (path denial, edit failure, mode violation, etc.) and stored with the trust score at failure time.
@@ -84,15 +100,18 @@ The CLI and MCP server are thin shells that auto-discover and compose from regis
 
 ### DuckDB Persistence
 
-All data is stored in a local DuckDB database (`.riggs/store.duckdb`). Schema is managed idempotently — plugins declare their tables via `CREATE TABLE IF NOT EXISTS`. No migrations or daemon required.
+Analytics data (turns, failure stream, ratchet decisions, metrics) is stored in a local DuckDB database (`.riggs/store.duckdb`). Schema is managed idempotently — plugins declare their tables via `CREATE TABLE IF NOT EXISTS`. No migrations or daemon required.
+
+The authoritative **trust state** does not live here: it lives in an append-only, HMAC-chained ledger outside the project tree, so the scored agent cannot reset or rewrite it. See [Trust Integrity](docs/trust-integrity.md).
 
 ## Usage
 
 ### CLI Commands
 
 ```bash
-agent-riggs init                    # Initialize .riggs/ config and store
+agent-riggs init                    # Initialize .riggs/ config, store, and trust state dir
 agent-riggs ingest                  # Pull events from sibling tools (kibitzer, blq, etc.)
+agent-riggs gate                    # Fail-closed trust gate check (exit 0 allow / 2 deny)
 agent-riggs status                  # Show current trust scores and recent events
 agent-riggs trust [--window {1,5,15}]
                                     # Display trust window and trajectory
@@ -125,6 +144,7 @@ Agents can then access:
 
 **Tools** (read-only):
 - `RiggsTrust` — Query trust window and history
+- `RiggsGate` — Fail-closed gate decision for capability-expanding actions
 - `RiggsMetrics` — Compute metrics over a period
 - `RiggsFailures` — Query failure stream by category
 - `RiggsSandbox` — Get sandbox profile for a command
@@ -133,7 +153,7 @@ Agents can then access:
 
 ### .riggs/config.toml
 
-Configuration is loaded from `.riggs/config.toml` with sensible defaults shipped in the package. User config merges over defaults.
+Configuration is loaded from `.riggs/config.toml` with sensible defaults shipped in the package. User config merges over defaults — **except the `[trust]` section**: trust scoring and gate policy are never read from the project tree (the scored agent can edit it). Trust policy comes from the shipped defaults, optionally overridden by `policy.toml` in the out-of-tree state directory (see [Trust Integrity](docs/trust-integrity.md)).
 
 Example sections:
 
@@ -184,8 +204,8 @@ path = ".riggs/store.duckdb"
 ### Reads Everything, Writes Nothing (to other tools)
 Riggs is a **read-only observer** of the Rigged tool suite. It ingests state from kibitzer, blq, jetsam, and fledgling but never mutates their configs or data directly. Promotions are written to `.riggs/` only, then reviewed by humans before application.
 
-### Human in the Loop
-Riggs recommends but never enforces. All promotion decisions require human review and approval. Constraint tightening is suggested, not automatic.
+### Human in the Loop, Gate at the Boundary
+Promotion decisions require human review and approval, and mode control stays with kibitzer. What riggs itself guarantees is the **fail-closed trust gate**: capability-expanding actions (tool promotions, LOOSEN recommendations, `agent-riggs gate` consumers) are denied unless verified trust history supports them. Constraint tightening is suggested, never gated.
 
 ### Specified Throughout
 Every threshold, weight, and heuristic is configurable in `.riggs/config.toml`. Defaults are sensible but tunable.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -87,6 +87,22 @@ Active ratchet candidates: 2
 
 ## Trust Commands
 
+### agent-riggs gate
+
+Fail-closed trust gate check. Exit code `0` = allow, `2` = deny. Intended
+for harness hooks: consult it before granting the agent expanded capability.
+Denies on absent or unverifiable trust state, trust below the gate
+threshold, or a recent violation. See [Trust Integrity](trust-integrity.md).
+
+```bash
+agent-riggs gate
+```
+
+```
+DENY: no verified trust history; unknown subjects are low trust (fail closed)
+trust: 0.00 / 0.00 / 0.00 (state: absent)
+```
+
 ### agent-riggs trust current
 
 Detailed trust scores.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,14 @@ Agent Riggs is configured through `.riggs/config.toml`. When you run `agent-rigg
 
 ## [trust]
 
-Trust scoring weights and EWMA parameters.
+Trust scoring weights, EWMA parameters, and gate policy.
+
+**Security note:** unlike every other section, `[trust]` is **not** read from
+the project's `.riggs/config.toml` — that file is writable by the scored
+agent, which could otherwise weaken its own scoring and gate thresholds. The
+values here are the shipped defaults; to override them, put a `[trust]`
+section in `policy.toml` inside the out-of-tree state directory (see
+[Trust Integrity](trust-integrity.md)).
 
 ### Scoring Weights
 
@@ -39,7 +46,15 @@ When trust crosses these thresholds, Riggs generates recommendations:
 | `tighten_threshold` | float | 0.3 | trust_1 below this triggers a tightening recommendation |
 | `auto_tighten_threshold` | float | 0.5 | trust_5 below this (combined with low trust_1) triggers auto-tighten |
 | `loosen_threshold` | float | 0.9 | trust_1 above this may trigger a loosening suggestion |
-| `loosen_sustained_turns` | int | 20 | Turns of sustained high trust required before suggesting loosening |
+| `loosen_sustained_turns` | int | 20 | Consecutive trailing turns of high trust required before suggesting loosening |
+
+### Gate Policy
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `initial_trust` | float | 0.4 | EWMA seed for a subject with no verified history (below the gate threshold: trust must be accrued) |
+| `gate_threshold` | float | 0.5 | The gate denies when min(trust_1, trust_5) is below this |
+| `violation_holdoff_turns` | int | 20 | A failure-class event within this many ledger records keeps the gate closed |
 
 ## [ratchet]
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -33,7 +33,7 @@ Agent Riggs reads from sibling tools but never writes to their state. Each tool 
 | `success: false` | failure | 0.2 |
 | `success: false`, `error: "old_string not found"` | failure | 0.2 |
 
-**What Riggs writes back:** Trust-informed transition recommendations to `.kibitzer/state.json`. Kibitzer's mode controller reads these and acts on them.
+**What Riggs writes back:** Trust-informed transition recommendations to `.kibitzer/state.json` (written by each `agent-riggs ingest`, under the `riggs` key). Kibitzer's mode controller reads these and acts on them. The recommendation is advisory; the authoritative decision is the fail-closed gate over the verified trust ledger (see [Trust Integrity](trust-integrity.md)) — LOOSEN is only published when the gate allows it. Note: kibitzer's log entries are treated as *self-reported* evidence and can never raise trust, only hold or lower it.
 
 **When absent:** Without kibitzer, Riggs has no primary data source. The trust engine and ratchet work but have nothing to analyze.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -51,6 +51,14 @@ Get trust scores, optionally with history.
 
 **With window:** Returns current scores plus the last N trust entries.
 
+Current scores come from the verified out-of-tree trust ledger; absent or tampered state reads as low trust (fail closed). See [Trust Integrity](trust-integrity.md).
+
+### RiggsGate
+
+Fail-closed gate decision for capability-expanding actions. No parameters.
+
+Returns: `allowed` (bool), `reason`, `trust_1`/`trust_5`/`trust_15`, and the ledger `state` (`ok` / `absent` / `tampered`). Denies on absent or unverifiable trust state, trust below the gate threshold, or a violation within the holdoff window.
+
 ### RiggsMetrics
 
 Get ratchet metrics for a time period.
@@ -84,6 +92,6 @@ Returns: sandbox profiles with grades, headroom, and tightening recommendations.
 
 ## Read-Only Guarantee
 
-The MCP server opens the DuckDB store with `read_only=True`. This is enforced structurally — the database connection rejects any write operation. Agents can query freely without risk of data corruption.
+The MCP server opens the DuckDB store with `read_only=True`, and trust reads go to the verified out-of-tree ledger. Note the store's read-only mode protects riggs' own connection against accidental writes; it is not what protects trust integrity — the ledger is (see [Trust Integrity](trust-integrity.md)).
 
 All mutations go through the CLI (`agent-riggs ingest`, `agent-riggs ratchet promote`, etc.) which requires human action.

--- a/docs/the-ratchet.md
+++ b/docs/the-ratchet.md
@@ -32,7 +32,7 @@ When trust drops below thresholds, Riggs recommends action:
 | trust_1 > 0.9, trust_5 > 0.8 for 20+ turns | Suggest loosening |
 | trust_15 < 0.5 | "Project configuration needs review" |
 
-Riggs recommends. Kibitzer acts. Riggs never enforces directly.
+Riggs recommends; kibitzer controls the mode. Riggs' own enforcement point is the fail-closed trust gate: LOOSEN recommendations and tool promotions are denied unless verified trust history supports them (see [Trust Integrity](trust-integrity.md)).
 
 **Example:** The agent makes 5 consecutive failed edits. trust_1 drops to 0.18. Riggs writes a tighten recommendation to `.kibitzer/state.json`. Kibitzer's mode controller switches from `implement` to `debug`. The agent is now constrained to read-only tools until it can demonstrate it understands the problem.
 

--- a/docs/trust-integrity.md
+++ b/docs/trust-integrity.md
@@ -1,0 +1,113 @@
+# Trust Integrity Model
+
+The trust score exists to answer one question: *how much should this agent be
+trusted right now?* That answer is only useful if the scored agent (the
+"subject") cannot manufacture it. This page describes what riggs guarantees,
+how, and — just as importantly — where the boundary of the guarantee lies.
+
+## Threat model
+
+The subject is an agent session working in the project tree. It can read and
+write anything in the project (including `.riggs/`, `.kibitzer/`, `.lackpy/`,
+`.bird/`), run commands, and call riggs's CLI/MCP surfaces. It must not be
+able to:
+
+1. reset or rewrite its accumulated trust state,
+2. raise its trust by asserting its own success, or
+3. pass the trust gate without verified, sufficient, clean history.
+
+## The trust ledger
+
+Authoritative trust state lives in an **append-only, HMAC-chained ledger**
+stored *outside the project tree*:
+
+- Location: `$AGENT_RIGGS_STATE_DIR` (if set), else
+  `$XDG_STATE_HOME/agent-riggs`, else `~/.local/state/agent-riggs`, in a
+  per-project subdirectory keyed by the *resolved project path* — not by any
+  project-local config the subject could edit.
+- Each record carries an HMAC (key created `0600` in a `0700` directory)
+  over its payload chained to the previous record's MAC; a MAC'd head file
+  pins the last record so truncation is detected.
+- Verification failure of any kind reads as **`tampered`**; a missing ledger
+  reads as **`absent`**. Both are treated as **low trust** (fail closed).
+  Deleting state never grants trust — it removes it.
+
+The project-local DuckDB store (`.riggs/store.duckdb`) is **analytics only**.
+It feeds briefings, metrics, and candidate mining, but nothing security
+relevant reads trust values from it: deleting it or inserting forged rows
+does not change the verified trust state.
+
+## Provenance: observed vs self-reported
+
+Every ingested event carries a provenance:
+
+- **OBSERVED** — recorded by an independent process from the actual outcome.
+  Today that is blq's real exit codes. Observed events update the EWMA
+  normally and are the only way to *raise* trust.
+- **SELF_REPORTED** — asserted by the subject or read from a file the
+  subject can write (kibitzer intercept log, lackpy traces, conversation
+  transcripts). These update the EWMA with a per-window
+  `min(score, window)` cap: they can hold or *lower* trust (claims against
+  interest count) but can never raise it.
+
+An unknown subject starts at `initial_trust` (default 0.4, below the gate
+threshold) and must accrue trust from observed evidence. Ingest is
+idempotent — every event has a stable UID recorded in the ledger, so
+replaying `ingest` or re-reading the same logs cannot re-count evidence.
+
+## The gate
+
+`agent-riggs gate` (CLI, exit `0` allow / `2` deny) and the `RiggsGate` MCP
+tool evaluate the fail-closed gate. It is also invoked internally before
+capability-expanding actions: ratchet **tool promotions** (constraint
+promotions tighten and are never gated) and the LOOSEN recommendation
+published to `.kibitzer/state.json`.
+
+Deny conditions:
+
+| Condition | Decision |
+|---|---|
+| ledger absent | deny — unknown subjects are low trust |
+| ledger fails verification | deny — and `ingest` refuses to run |
+| `min(t1, t5)` below `gate_threshold` (default 0.5) | deny |
+| violation within the last `violation_holdoff_turns` (default 20) records | deny |
+
+The holdoff makes serious incidents *sticky*: a failure cannot be washed out
+of the gate by a quick burst of successes even though the short EWMA window
+recovers fast.
+
+## Trust policy is not subject-configurable
+
+The `[trust]` section (scoring weights, alphas, thresholds, gate policy) is
+**never read from `.riggs/config.toml`** — that file is subject-writable, and
+policy read from it would let the subject weaken its own scoring. Policy
+comes from the shipped defaults, optionally overridden by `policy.toml` in
+the out-of-tree state directory.
+
+## Limits of the guarantee — read this
+
+Riggs is a Python package, not an operating system. The integrity mechanisms
+hold **only if the state directory is outside the subject's write scope**:
+
+- **Deployment guidance:** point `AGENT_RIGGS_STATE_DIR` at a directory
+  owned by a separate user (or otherwise excluded from the agent's sandbox
+  write scope, e.g. via your harness's permission system) and run
+  `agent-riggs ingest` / `agent-riggs gate` under that identity. If the
+  subject can read the HMAC key or replace the whole state directory with a
+  snapshot taken at a high-trust moment, the chain does not protect you.
+- **Evidence files are only as trustworthy as their protection.** blq's
+  database is classified OBSERVED because blq records real exit codes, but
+  it lives in the project tree; a subject that fabricates a plausible blq
+  database can still manufacture observed successes. Where that matters,
+  protect `.bird/` the same way or ingest from a location the subject
+  cannot write.
+- **Concurrent ingests** are not locked; interleaved appends will read as
+  `tampered` (fail closed — recoverable by consciously resetting the state
+  directory, which resets trust to *low*, not high).
+
+Within a single-user account with no write restrictions at all, riggs
+degrades to tamper-*evident* bookkeeping against accidental corruption; it
+cannot be tamper-*proof* against that account. The gate, provenance rules,
+and fail-closed defaults still remove every in-band self-elevation path —
+`rm`-to-reset, store edits, self-reported success, config weakening, and
+replay.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -193,11 +193,11 @@ When trust drops below configured thresholds, Riggs generates recommendations:
 | trust_1 > 0.9 AND trust_5 > 0.8 for 20+ turns | Suggest loosening |
 | trust_15 < 0.5 | Flag: "project configuration needs review" |
 
-In our second session, trust_1 hit 0.24 — below the tighten threshold. If kibitzer were running, Riggs would write a recommendation to `.kibitzer/state.json`, and kibitzer's mode controller would pick it up.
+In our second session, trust_1 hit 0.24 — below the tighten threshold. Each `agent-riggs ingest` writes the current recommendation to `.kibitzer/state.json`, and kibitzer's mode controller picks it up.
 
-This is how Riggs and kibitzer work together: Riggs observes across sessions and recommends. Kibitzer acts within the session. Riggs never enforces directly — it informs kibitzer's rules.
+This is how Riggs and kibitzer work together: Riggs observes across sessions and recommends; kibitzer controls the mode within the session. Riggs' own enforcement point is the **fail-closed trust gate** (`agent-riggs gate`), which capability-expanding actions must pass — see [Trust Integrity](trust-integrity.md).
 
-All thresholds are configurable in `.riggs/config.toml` under `[trust]`. See [Configuration](configuration.md) for details.
+Trust thresholds and gate policy are **not** read from `.riggs/config.toml` (the scored agent can edit that file); they come from shipped defaults plus `policy.toml` in the out-of-tree state directory. See [Trust Integrity](trust-integrity.md) and [Configuration](configuration.md) for details.
 
 ## 8. Ratchet Candidates
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Home: index.md
   - Tutorial: tutorial.md
   - The Ratchet: the-ratchet.md
+  - Trust Integrity: trust-integrity.md
   - Reference:
     - CLI: cli-reference.md
     - Configuration: configuration.md

--- a/src/agent_riggs/cli.py
+++ b/src/agent_riggs/cli.py
@@ -37,8 +37,13 @@ def init() -> None:
         config_path.write_text(defaults_ref.read_text(encoding="utf-8"))
 
     from agent_riggs.assembly import assemble
+    from agent_riggs.trust.ledger import TrustLedger
 
     service = assemble(project_root)
+
+    # Create the out-of-tree trust state dir + signing key up front.
+    ledger = TrustLedger(project_root)
+    ledger.ensure_initialized()
 
     tools = []
     for name in ("kibitzer", "blq", "jetsam", "fledgling"):
@@ -46,6 +51,7 @@ def init() -> None:
             tools.append(name)
 
     click.echo(f"Initialized .riggs/ in {project_root}")
+    click.echo(f"Trust state directory: {ledger.dir}")
     if tools:
         click.echo(f"Discovered tools: {', '.join(tools)}")
     else:
@@ -58,14 +64,22 @@ def init() -> None:
 def ingest() -> None:
     """Ingest session data from sibling tools."""
     from agent_riggs.assembly import assemble
+    from agent_riggs.trust.ledger import LedgerIntegrityError
 
     project_root = find_project_root()
     service = assemble(project_root)
 
     ingest_plugin = service.plugin("ingest")
-    result = ingest_plugin.run()
+    try:
+        result = ingest_plugin.run()
+    except LedgerIntegrityError as exc:
+        click.echo(f"REFUSED: {exc}", err=True)
+        service.store.close()
+        raise SystemExit(2) from exc
 
     click.echo(f"Ingested {result.turns_ingested} turns from {result.sources_read}")
+    if result.duplicates_skipped:
+        click.echo(f"Skipped {result.duplicates_skipped} already-recorded events")
     if result.failures_recorded:
         click.echo(f"Recorded {result.failures_recorded} failures")
 
@@ -84,8 +98,12 @@ def status() -> None:
     data = trust_plugin.current()
 
     if not data["has_data"]:
-        click.echo("trust: no data yet")
-        click.echo("\nRun `agent-riggs ingest` after a session.")
+        if data.get("state") == "tampered":
+            click.echo("trust: STATE FAILED INTEGRITY VERIFICATION (fail closed, low trust)")
+            click.echo(f"       {data.get('detail', '')}")
+        else:
+            click.echo("trust: no verified data yet (low trust)")
+            click.echo("\nRun `agent-riggs ingest` after a session.")
     else:
         click.echo(
             f"trust: {data['trust_1']:.2f} / {data['trust_5']:.2f} / {data['trust_15']:.2f}"
@@ -93,6 +111,30 @@ def status() -> None:
         click.echo("       now    session  baseline")
 
     service.store.close()
+
+
+# --- Gate command ---
+
+
+@main.command("gate")
+def gate_cmd() -> None:
+    """Fail-closed trust gate check (exit 0 = allow, 2 = deny).
+
+    Intended for harness hooks: consult this before granting the agent
+    expanded capability. Denies on absent/tampered trust state, low trust,
+    or recent violations.
+    """
+    from agent_riggs.trust.gate import TrustGate
+
+    decision = TrustGate(find_project_root()).check()
+    verdict = "ALLOW" if decision.allowed else "DENY"
+    click.echo(f"{verdict}: {decision.reason}")
+    click.echo(
+        f"trust: {decision.trust_1:.2f} / {decision.trust_5:.2f} / {decision.trust_15:.2f} "
+        f"(state: {decision.state})"
+    )
+    if not decision.allowed:
+        raise SystemExit(2)
 
 
 # --- Trust commands ---
@@ -176,6 +218,10 @@ def ratchet_promote(key: str, reason: str | None) -> None:
         click.echo(f"Promoted: {key}")
     except KeyError:
         click.echo(f"No candidate with key: {key}", err=True)
+    except PermissionError as exc:
+        click.echo(f"DENIED: {exc}", err=True)
+        service.store.close()
+        raise SystemExit(2) from exc
     service.store.close()
 
 

--- a/src/agent_riggs/config.py
+++ b/src/agent_riggs/config.py
@@ -1,4 +1,12 @@
-"""Configuration loading: merge defaults with .riggs/config.toml."""
+"""Configuration loading: merge defaults with .riggs/config.toml.
+
+Security note: the ``[trust]`` section is *never* read from the project's
+``.riggs/config.toml``. That file is writable by the scored subject, and
+trust scoring/gating policy derived from it would be forgeable (the subject
+could set ``score_failure = 1.0`` or ``gate_threshold = 0.0``). Trust policy
+comes from the shipped defaults, optionally overridden by ``policy.toml`` in
+the out-of-tree state directory (see :mod:`agent_riggs.statedir`).
+"""
 
 from __future__ import annotations
 
@@ -7,6 +15,8 @@ from dataclasses import dataclass, field, fields
 from importlib import resources
 from pathlib import Path
 from typing import Any
+
+from agent_riggs.statedir import state_dir_for
 
 
 @dataclass
@@ -25,6 +35,12 @@ class TrustConfig:
     auto_tighten_threshold: float = 0.5
     loosen_threshold: float = 0.9
     loosen_sustained_turns: int = 20
+    # Seed for a subject with no verified history: LOW, must accrue.
+    initial_trust: float = 0.4
+    # The gate denies when min(t1, t5) is below this.
+    gate_threshold: float = 0.5
+    # A violation within this many ledger records keeps the gate closed.
+    violation_holdoff_turns: int = 20
 
 
 @dataclass
@@ -85,8 +101,29 @@ def _dict_to_dataclass(cls: type, data: dict[str, Any]) -> Any:
     return cls(**{k: v for k, v in data.items() if k in known})
 
 
+def load_trusted_trust_config(project_root: Path | str) -> TrustConfig:
+    """Load the trust policy from trusted sources only.
+
+    Sources, in order: shipped defaults, then ``policy.toml`` in the
+    out-of-tree state directory. The subject-writable
+    ``.riggs/config.toml`` is deliberately ignored — trust policy read from
+    the project tree would let the scored subject weaken its own scoring
+    and gate thresholds.
+    """
+    merged = _load_defaults().get("trust", {})
+    policy_path = state_dir_for(project_root) / "policy.toml"
+    if policy_path.exists():
+        policy = tomllib.loads(policy_path.read_text(encoding="utf-8"))
+        merged = _deep_merge(merged, policy.get("trust", {}))
+    return _dict_to_dataclass(TrustConfig, merged)
+
+
 def load_config(project_root: Path) -> RiggsConfig:
-    """Load config: defaults merged with .riggs/config.toml."""
+    """Load config: defaults merged with .riggs/config.toml.
+
+    The ``[trust]`` section is sourced via :func:`load_trusted_trust_config`
+    and cannot be overridden from the project tree (see module docstring).
+    """
     merged = _load_defaults()
 
     user_path = project_root / ".riggs" / "config.toml"
@@ -95,7 +132,7 @@ def load_config(project_root: Path) -> RiggsConfig:
         merged = _deep_merge(merged, user)
 
     return RiggsConfig(
-        trust=_dict_to_dataclass(TrustConfig, merged.get("trust", {})),
+        trust=load_trusted_trust_config(project_root),
         ratchet=_dict_to_dataclass(RatchetConfig, merged.get("ratchet", {})),
         sandbox=_dict_to_dataclass(SandboxConfig, merged.get("sandbox", {})),
         metrics=_dict_to_dataclass(MetricsConfig, merged.get("metrics", {})),

--- a/src/agent_riggs/defaults/config.toml
+++ b/src/agent_riggs/defaults/config.toml
@@ -16,6 +16,14 @@ auto_tighten_threshold = 0.5
 loosen_threshold = 0.9
 loosen_sustained_turns = 20
 
+# Security-sensitive gate policy. NOTE: the [trust] section is only ever
+# read from these shipped defaults or from policy.toml in the out-of-tree
+# state directory — never from the project's .riggs/config.toml, which the
+# scored subject can edit.
+initial_trust = 0.4
+gate_threshold = 0.5
+violation_holdoff_turns = 20
+
 [ratchet]
 min_frequency = 5
 min_sessions = 3

--- a/src/agent_riggs/ingest/pipeline.py
+++ b/src/agent_riggs/ingest/pipeline.py
@@ -1,16 +1,38 @@
-"""Ingest pipeline: discover sources, read events, score, store."""
+"""Ingest pipeline: discover sources, read events, score, record, store.
+
+Integrity model:
+
+* The authoritative trust state is the out-of-tree, HMAC-chained
+  :class:`~agent_riggs.trust.ledger.TrustLedger` — not the project-local
+  DuckDB store, which is analytics only and writable by the scored subject.
+* The EWMA is seeded from the *verified* ledger; with no ledger it starts at
+  ``TrustConfig.initial_trust`` (low — an unknown subject must accrue trust).
+* Events whose provenance is SELF_REPORTED are applied with
+  ``allow_increase=False``: they can hold or lower trust, never raise it.
+* Ingest is idempotent: each event carries a stable ``event_uid`` and events
+  already present in the ledger are skipped, so replaying ``ingest`` (or
+  re-reading the same logs) cannot re-count evidence.
+* Events are applied in timestamp order across all sources, so the result
+  does not depend on source iteration order.
+* If the ledger fails verification, ingest refuses to run
+  (:class:`~agent_riggs.trust.ledger.LedgerIntegrityError`) rather than
+  build new trust on top of tampered state.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 
 from agent_riggs.config import TrustConfig
 from agent_riggs.ingest.sources.base import Source
 from agent_riggs.store import Store
-from agent_riggs.trust.events import EventCategory
+from agent_riggs.trust.events import EventCategory, Provenance, TurnEvent
 from agent_riggs.trust.ewma import TrustEWMA
+from agent_riggs.trust.ledger import LedgerIntegrityError, LedgerState, TrustLedger
 from agent_riggs.trust.scorer import score_event
 
 _FAILURE_CATEGORIES = frozenset(
@@ -32,7 +54,37 @@ def _next_id(store: Store, table: str, column: str) -> int:
 class IngestResult:
     turns_ingested: int = 0
     failures_recorded: int = 0
+    duplicates_skipped: int = 0
     sources_read: list[str] = field(default_factory=list)
+
+
+def _fallback_uid(source_name: str, event: TurnEvent) -> str:
+    raw = (
+        f"{source_name}:{event.session_id}:{event.turn_number}:"
+        f"{event.timestamp.isoformat()}:{event.event_category.value}"
+    )
+    return f"{source_name}:{hashlib.sha256(raw.encode()).hexdigest()[:16]}"
+
+
+def _sort_key(event: TurnEvent) -> datetime:
+    ts = event.timestamp
+    return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+
+
+def ewma_from_ledger(state: LedgerState, config: TrustConfig) -> TrustEWMA:
+    """Seed the EWMA from verified ledger state; unknown subjects start LOW."""
+    ewma = TrustEWMA(
+        alpha_short=config.alpha_short,
+        alpha_session=config.alpha_session,
+        alpha_baseline=config.alpha_baseline,
+        initial=config.initial_trust,
+    )
+    last = state.last
+    if state.status == "ok" and last is not None:
+        ewma.t1 = last.t1
+        ewma.t5 = last.t5
+        ewma.t15 = last.t15
+    return ewma
 
 
 def ingest(
@@ -41,53 +93,67 @@ def ingest(
     sources: list[Source],
     trust_config: TrustConfig,
     since: object | None = None,
+    ledger: TrustLedger | None = None,
 ) -> IngestResult:
-    """Pull events from all discovered sources, score, and store."""
+    """Pull events from all discovered sources, score, record, and store."""
     result = IngestResult()
     project = project_root.name
 
-    ewma = _load_or_create_ewma(store, project, trust_config)
+    ledger = ledger if ledger is not None else TrustLedger(project_root)
+    state = ledger.verify()
+    if state.status == "tampered":
+        raise LedgerIntegrityError(
+            f"trust ledger failed integrity verification ({state.detail}); "
+            "refusing to ingest on top of tampered state"
+        )
+    known_uids = {r.event_uid for r in state.records}
+
+    ewma = ewma_from_ledger(state, trust_config)
     next_turn_id = _next_id(store, "turns", "turn_id")
 
+    pending: list[tuple[str, TurnEvent]] = []
     for source in sources:
         if not source.discover(project_root):
             continue
         result.sources_read.append(source.name)
-        events = source.read_events(project_root, since)
+        for event in source.read_events(project_root, since):
+            pending.append((source.name, event))
 
-        for event in events:
-            score = score_event(event, trust_config)
-            t1, t5, t15 = ewma.update(score)
-            turn_id = next_turn_id
-            next_turn_id += 1
+    # Apply in timestamp order so results don't depend on source order.
+    pending.sort(key=lambda pair: _sort_key(pair[1]))
 
-            _store_turn(store, turn_id, project, event, score, t1, t5, t15)
-            result.turns_ingested += 1
+    for source_name, event in pending:
+        uid = event.event_uid or _fallback_uid(source_name, event)
+        if uid in known_uids:
+            result.duplicates_skipped += 1
+            continue
+        known_uids.add(uid)
 
-            if event.event_category in _FAILURE_CATEGORIES:
-                _store_failure(store, turn_id, project, event, score)
-                result.failures_recorded += 1
+        score = score_event(event, trust_config)
+        observed = event.provenance is Provenance.OBSERVED
+        t1, t5, t15 = ewma.update(score, allow_increase=observed)
+        turn_id = next_turn_id
+        next_turn_id += 1
+
+        ledger.append(
+            event_uid=uid,
+            session_id=event.session_id,
+            category=event.event_category.value,
+            score=score,
+            t1=t1,
+            t5=t5,
+            t15=t15,
+            observed=observed,
+            timestamp=event.timestamp,
+        )
+        _store_turn(store, turn_id, project, event, score, t1, t5, t15)
+        result.turns_ingested += 1
+
+        if event.event_category in _FAILURE_CATEGORIES:
+            _store_failure(store, turn_id, project, event, score)
+            result.failures_recorded += 1
 
     return result
-
-
-def _load_or_create_ewma(store: Store, project: str, config: TrustConfig) -> TrustEWMA:
-    row = store.execute(
-        """SELECT trust_1, trust_5, trust_15 FROM turns
-           WHERE project = ? ORDER BY timestamp DESC LIMIT 1""",
-        [project],
-    ).fetchone()
-
-    ewma = TrustEWMA(
-        alpha_short=config.alpha_short,
-        alpha_session=config.alpha_session,
-        alpha_baseline=config.alpha_baseline,
-    )
-    if row:
-        ewma.t1 = row[0]
-        ewma.t5 = row[1]
-        ewma.t15 = row[2]
-    return ewma
 
 
 def _store_turn(store, turn_id, project, event, score, t1, t5, t15):

--- a/src/agent_riggs/ingest/sources/blq.py
+++ b/src/agent_riggs/ingest/sources/blq.py
@@ -1,4 +1,10 @@
-"""blq ingest source — reads .bird/blq.duckdb build/test execution data."""
+"""blq ingest source — reads .bird/blq.duckdb build/test execution data.
+
+Provenance: OBSERVED. blq records real process exit codes at execution time,
+independently of what the session claims about its own success. (The
+database file itself is only as protected as the deployment makes it — see
+the trust-integrity docs.)
+"""
 
 from __future__ import annotations
 
@@ -7,7 +13,7 @@ from pathlib import Path
 
 import duckdb
 
-from agent_riggs.trust.events import EventCategory, TurnEvent
+from agent_riggs.trust.events import EventCategory, Provenance, TurnEvent
 
 
 class BlqSource:
@@ -64,6 +70,8 @@ class BlqSource:
                         "source": "blq",
                         "invocation_id": str(inv_id),
                     },
+                    provenance=Provenance.OBSERVED,
+                    event_uid=f"blq:{inv_id}",
                 )
             )
         return events

--- a/src/agent_riggs/ingest/sources/fledgling.py
+++ b/src/agent_riggs/ingest/sources/fledgling.py
@@ -1,12 +1,19 @@
-"""Fledgling ingest source — reads Claude Code conversation JSONL logs."""
+"""Fledgling ingest source — reads Claude Code conversation JSONL logs.
+
+Provenance: SELF_REPORTED. Transcripts are written by the harness, but they
+live under the subject's home directory and the ``tool_success`` recorded
+here is assumed rather than verified against real outcomes — so these events
+can hold or lower trust, never raise it.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from agent_riggs.trust.events import EventCategory, TurnEvent
+from agent_riggs.trust.events import EventCategory, Provenance, TurnEvent
 
 # Tools that have structured alternatives (from kibitzer's interceptor patterns)
 _BASH_PATTERNS_WITH_ALTERNATIVES = {
@@ -30,7 +37,7 @@ class FledglingSource:
         # Check if any project dir has JSONL files
         for project_dir in claude_dir.iterdir():
             if project_dir.is_dir():
-                for f in project_dir.glob("*.jsonl"):
+                for _ in project_dir.glob("*.jsonl"):
                     return True
         return False
 
@@ -75,6 +82,12 @@ class FledglingSource:
                         tool_name = block.get("name", "unknown")
                         tool_input = block.get("input", {})
                         category = self._classify(tool_name, tool_input)
+                        block_id = block.get("id")
+                        if block_id:
+                            uid = f"fledgling:{block_id}"
+                        else:
+                            raw = f"{session_id}:{ts.isoformat()}:{turn_counter}:{tool_name}"
+                            uid = f"fledgling:{hashlib.sha256(raw.encode()).hexdigest()[:16]}"
                         events.append(
                             TurnEvent(
                                 session_id=session_id,
@@ -89,6 +102,8 @@ class FledglingSource:
                                     "model": message.get("model"),
                                     "source": "fledgling",
                                 },
+                                provenance=Provenance.SELF_REPORTED,
+                                event_uid=uid,
                             )
                         )
 

--- a/src/agent_riggs/ingest/sources/kibitzer.py
+++ b/src/agent_riggs/ingest/sources/kibitzer.py
@@ -1,12 +1,18 @@
-"""Kibitzer ingest source — reads .kibitzer/state.json and intercept.log."""
+"""Kibitzer ingest source — reads .kibitzer/state.json and intercept.log.
+
+Provenance: SELF_REPORTED. The intercept log lives in the project tree and
+its ``success`` field is supplied by the scored session, so it is treated as
+an unverified claim — it can hold or lower trust, never raise it.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from agent_riggs.trust.events import EventCategory, TurnEvent
+from agent_riggs.trust.events import EventCategory, Provenance, TurnEvent
 
 
 class KibitzerSource:
@@ -29,9 +35,11 @@ class KibitzerSource:
 
     def _read_state(self, project_root: Path) -> dict:
         state_path = project_root / ".kibitzer" / "state.json"
-        if state_path.exists():
-            return json.loads(state_path.read_text())
-        return {}
+        try:
+            state = json.loads(state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return state if isinstance(state, dict) else {}
 
     def _parse_intercept_log(
         self,
@@ -46,10 +54,17 @@ class KibitzerSource:
                 line = line.strip()
                 if not line:
                     continue
-                entry = json.loads(line)
-                ts = self._parse_timestamp(entry.get("timestamp", ""))
+                # One malformed (subject-controlled) line must not abort ingest.
+                try:
+                    entry = json.loads(line)
+                    if not isinstance(entry, dict):
+                        continue
+                    ts = self._parse_timestamp(entry.get("timestamp", ""))
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    continue
                 if since and ts < since:
                     continue
+                digest = hashlib.sha256(line.encode()).hexdigest()[:16]
                 events.append(
                     TurnEvent(
                         session_id=session_id,
@@ -60,6 +75,8 @@ class KibitzerSource:
                         mode=mode,
                         event_category=self._classify(entry),
                         metadata=entry,
+                        provenance=Provenance.SELF_REPORTED,
+                        event_uid=f"kibitzer:{i}:{digest}",
                     )
                 )
         return events
@@ -76,5 +93,5 @@ class KibitzerSource:
     def _parse_timestamp(self, ts_str: str) -> datetime:
         if not ts_str:
             return datetime.now(UTC)
-        ts_str = ts_str.replace("Z", "+00:00")
+        ts_str = str(ts_str).replace("Z", "+00:00")
         return datetime.fromisoformat(ts_str)

--- a/src/agent_riggs/ingest/sources/lackpy.py
+++ b/src/agent_riggs/ingest/sources/lackpy.py
@@ -1,12 +1,18 @@
-"""Lackpy ingest source — reads .lackpy/traces.jsonl delegation traces."""
+"""Lackpy ingest source — reads .lackpy/traces.jsonl delegation traces.
+
+Provenance: SELF_REPORTED. The traces file lives in the project tree and its
+``success`` field is not independently verified, so it can hold or lower
+trust but never raise it.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from agent_riggs.trust.events import EventCategory, TurnEvent
+from agent_riggs.trust.events import EventCategory, Provenance, TurnEvent
 
 # Generation tiers that don't require model inference
 _STRUCTURED_TIERS = frozenset({"templates", "rules"})
@@ -29,10 +35,17 @@ class LackpySource:
                 line = line.strip()
                 if not line:
                     continue
-                entry = json.loads(line)
-                ts = self._parse_timestamp(entry.get("timestamp", ""))
+                # One malformed line must not abort the whole ingest.
+                try:
+                    entry = json.loads(line)
+                    if not isinstance(entry, dict):
+                        continue
+                    ts = self._parse_timestamp(entry.get("timestamp", ""))
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    continue
                 if since and ts < since:
                     continue
+                digest = hashlib.sha256(line.encode()).hexdigest()[:16]
                 events.append(
                     TurnEvent(
                         session_id=f"lackpy-{ts.strftime('%Y%m%d')}",
@@ -43,6 +56,8 @@ class LackpySource:
                         mode=None,
                         event_category=self._classify(entry),
                         metadata=entry,
+                        provenance=Provenance.SELF_REPORTED,
+                        event_uid=f"lackpy:{i}:{digest}",
                     )
                 )
         return events
@@ -58,5 +73,5 @@ class LackpySource:
     def _parse_timestamp(self, ts_str: str) -> datetime:
         if not ts_str:
             return datetime.now(UTC)
-        ts_str = ts_str.replace("Z", "+00:00")
+        ts_str = str(ts_str).replace("Z", "+00:00")
         return datetime.fromisoformat(ts_str)

--- a/src/agent_riggs/plugins/ingest.py
+++ b/src/agent_riggs/plugins/ingest.py
@@ -38,13 +38,90 @@ class IngestPlugin:
 
     def run(self, since: datetime | None = None) -> IngestResult:
         sources = self._discover_sources()
-        return ingest(
+        result = ingest(
             store=self.service.store,
             project_root=self.service.project_root,
             sources=sources,
             trust_config=self.service.config.trust,
             since=since,
         )
+        self._publish_recommendation()
+        return result
 
     def _discover_sources(self) -> list[Any]:
         return [BlqSource(), FledglingSource(), KibitzerSource(), LackpySource()]
+
+    def _publish_recommendation(self) -> None:
+        """Write the trust-informed recommendation to .kibitzer/state.json.
+
+        This is the advisory half of the loop (kibitzer's mode controller
+        reads it); the authoritative decision is the fail-closed gate over
+        the verified ledger, which is what the recommendation is derived
+        from. state.json lives in the project tree and is not integrity
+        protected.
+        """
+        import json
+        from datetime import UTC
+        from datetime import datetime as dt
+
+        from agent_riggs.config import load_trusted_trust_config
+        from agent_riggs.trust.gate import evaluate_gate
+        from agent_riggs.trust.ledger import TrustLedger
+        from agent_riggs.trust.transitions import recommend_transition
+
+        root = self.service.project_root
+        state_path = root / ".kibitzer" / "state.json"
+        if not state_path.parent.exists():
+            return
+
+        config = load_trusted_trust_config(root)
+        ledger_state = TrustLedger(root).verify()
+        gate = evaluate_gate(ledger_state, config)
+
+        recommendation = None
+        if ledger_state.status == "ok" and ledger_state.last is not None:
+            last = ledger_state.last
+            sustained = 0
+            for record in reversed(ledger_state.records):
+                if record.t1 > config.loosen_threshold:
+                    sustained += 1
+                else:
+                    break
+            rec = recommend_transition(
+                t1=last.t1,
+                t5=last.t5,
+                t15=last.t15,
+                sustained_high_turns=sustained,
+                config=config,
+            )
+            if rec is not None:
+                # LOOSEN is capability-expanding: only publish it if the
+                # fail-closed gate agrees.
+                if rec.action.value == "loosen" and not gate.allowed:
+                    recommendation = {"action": "hold", "reason": gate.reason}
+                else:
+                    recommendation = {"action": rec.action.value, "reason": rec.reason}
+        else:
+            recommendation = {
+                "action": "auto_tighten",
+                "reason": f"trust state {ledger_state.status} (fail closed)",
+            }
+
+        try:
+            data = json.loads(state_path.read_text()) if state_path.exists() else {}
+            if not isinstance(data, dict):
+                data = {}
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        data["riggs"] = {
+            "recommendation": recommendation,
+            "gate": {"allowed": gate.allowed, "reason": gate.reason},
+            "trust": {
+                "trust_1": gate.trust_1,
+                "trust_5": gate.trust_5,
+                "trust_15": gate.trust_15,
+                "state": gate.state,
+            },
+            "updated_at": dt.now(UTC).isoformat(),
+        }
+        state_path.write_text(json.dumps(data, indent=2))

--- a/src/agent_riggs/plugins/ratchet.py
+++ b/src/agent_riggs/plugins/ratchet.py
@@ -59,6 +59,16 @@ class RatchetPlugin:
     def promote(self, key, reason=None):
         for c in self.candidates():
             if c.candidate_key == key:
+                if c.candidate_type == "tool_promotion":
+                    # Capability-expanding: consult the fail-closed trust gate.
+                    # (Constraint promotions tighten and are never gated.)
+                    from agent_riggs.trust.gate import TrustGate
+
+                    decision = TrustGate(self.service.project_root).check()
+                    if not decision.allowed:
+                        raise PermissionError(
+                            f"trust gate denied promotion of {key!r}: {decision.reason}"
+                        )
                 record_decision(self.service.store, c, "promoted", reason)
                 return
         raise KeyError(f"No candidate with key: {key}")

--- a/src/agent_riggs/plugins/trust.py
+++ b/src/agent_riggs/plugins/trust.py
@@ -96,29 +96,36 @@ class TrustPlugin:
         return [("riggs://trust", self._trust_resource)]
 
     def mcp_tools(self) -> list[tuple[str, Callable[..., Any]]]:
-        return [("RiggsTrust", self._trust_tool)]
+        return [("RiggsTrust", self._trust_tool), ("RiggsGate", self._gate_tool)]
 
     def current(self) -> dict[str, Any]:
-        """Get the most recent trust scores for the current project."""
-        row = self.store.execute(
-            """
-            SELECT trust_1, trust_5, trust_15, session_id, turn_number
-            FROM turns
-            WHERE project = ?
-            ORDER BY timestamp DESC
-            LIMIT 1
-            """,
-            [self._project_name()],
-        ).fetchone()
-        if row is None:
-            return {"trust_1": 1.0, "trust_5": 1.0, "trust_15": 1.0, "has_data": False}
+        """Get the current *verified* trust scores for this project.
+
+        Reads the out-of-tree HMAC-chained ledger, never the subject-writable
+        DuckDB store. Absent or tampered state reads as LOW trust (0.0), not
+        max — fail closed.
+        """
+        from agent_riggs.trust.ledger import TrustLedger
+
+        state = TrustLedger(self.service.project_root).verify()
+        if state.status != "ok" or state.last is None:
+            return {
+                "trust_1": 0.0,
+                "trust_5": 0.0,
+                "trust_15": 0.0,
+                "has_data": False,
+                "state": state.status,
+                "detail": state.detail,
+            }
+        last = state.last
         return {
-            "trust_1": row[0],
-            "trust_5": row[1],
-            "trust_15": row[2],
-            "session_id": row[3],
-            "turn_number": row[4],
+            "trust_1": last.t1,
+            "trust_5": last.t5,
+            "trust_15": last.t15,
+            "session_id": last.session_id,
+            "turn_number": last.seq,
             "has_data": True,
+            "state": state.status,
         }
 
     def history(self, limit: int = 50) -> list[dict[str, Any]]:
@@ -151,7 +158,15 @@ class TrustPlugin:
     def _trust_resource(self) -> str:
         data = self.current()
         if not data["has_data"]:
-            return "No trust data yet. Run `agent-riggs ingest` after a session."
+            if data.get("state") == "tampered":
+                return (
+                    "Trust state failed integrity verification (fail closed, low trust). "
+                    f"Detail: {data.get('detail', '')}"
+                )
+            return (
+                "No verified trust data yet (low trust). "
+                "Run `agent-riggs ingest` after a session."
+            )
         return (
             f"trust: {data['trust_1']:.2f} / {data['trust_5']:.2f} / {data['trust_15']:.2f}\n"
             f"       now    session  baseline"
@@ -161,3 +176,11 @@ class TrustPlugin:
         if window:
             return {"current": self.current(), "history": self.history(limit=window)}
         return {"current": self.current()}
+
+    def _gate_tool(self) -> dict[str, Any]:
+        """Fail-closed gate decision for capability-expanding actions."""
+        from dataclasses import asdict
+
+        from agent_riggs.trust.gate import TrustGate
+
+        return asdict(TrustGate(self.service.project_root).check())

--- a/src/agent_riggs/statedir.py
+++ b/src/agent_riggs/statedir.py
@@ -1,0 +1,49 @@
+"""Out-of-tree state directory for integrity-sensitive trust state.
+
+Trust state must not live in the project tree, because the project tree is
+writable by the scored subject (the agent whose behavior the trust score
+summarizes). State is keyed by the resolved project path so a subject
+cannot redirect it via project-local configuration.
+
+Resolution order for the base directory:
+
+1. ``AGENT_RIGGS_STATE_DIR`` environment variable (deployments and tests)
+2. ``$XDG_STATE_HOME/agent-riggs``
+3. ``~/.local/state/agent-riggs``
+
+Deployments that want a real ownership boundary should point
+``AGENT_RIGGS_STATE_DIR`` at a directory owned by a separate user (or
+otherwise outside the subject's write scope) and run ``agent-riggs ingest``
+/ ``agent-riggs gate`` under that identity. Inside a single-user account
+with no write restrictions, the separation is best-effort only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+ENV_STATE_DIR = "AGENT_RIGGS_STATE_DIR"
+
+
+def state_root() -> Path:
+    """Base directory for all agent-riggs trust state."""
+    env = os.environ.get(ENV_STATE_DIR)
+    if env:
+        return Path(env)
+    xdg = os.environ.get("XDG_STATE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "state"
+    return base / "agent-riggs"
+
+
+def state_dir_for(project_root: Path | str) -> Path:
+    """Per-project state directory, keyed by the resolved project path.
+
+    The key is derived from the resolved path (not from any project-local
+    config) so the scored subject cannot point riggs at a different state
+    directory by editing files inside the project.
+    """
+    resolved = Path(project_root).resolve()
+    digest = hashlib.sha256(str(resolved).encode()).hexdigest()[:16]
+    return state_root() / f"{resolved.name}-{digest}"

--- a/src/agent_riggs/trust/events.py
+++ b/src/agent_riggs/trust/events.py
@@ -18,6 +18,21 @@ class EventCategory(Enum):
     REPEATED_FAILURE = "repeated_failure"
 
 
+class Provenance(Enum):
+    """How an event's outcome was established.
+
+    OBSERVED: recorded by an independent process from the actual outcome
+    (e.g. a real exit code). May raise trust.
+
+    SELF_REPORTED: asserted by the scored subject, or read from a file the
+    subject can write. Must never raise trust — the pipeline applies these
+    with ``allow_increase=False`` so only claims against interest count.
+    """
+
+    OBSERVED = "observed"
+    SELF_REPORTED = "self_reported"
+
+
 @dataclass(frozen=True)
 class TurnEvent:
     session_id: str
@@ -28,3 +43,7 @@ class TurnEvent:
     mode: str | None
     event_category: EventCategory
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Safe default: unknown provenance is treated as self-reported.
+    provenance: Provenance = Provenance.SELF_REPORTED
+    # Stable identity for ingest idempotency; derived by the source.
+    event_uid: str | None = None

--- a/src/agent_riggs/trust/ewma.py
+++ b/src/agent_riggs/trust/ewma.py
@@ -25,19 +25,35 @@ class TrustEWMA:
         alpha_short: float = 0.4,
         alpha_session: float = 0.08,
         alpha_baseline: float = 0.02,
+        initial: float = 1.0,
     ) -> None:
+        """``initial`` is the seed for all three windows.
+
+        Security note: consumers scoring an *unknown* subject must seed low
+        (see ``TrustConfig.initial_trust``) — the pipeline does. The 1.0
+        default exists only for pure-math uses of this class.
+        """
         self.alpha_short = alpha_short
         self.alpha_session = alpha_session
         self.alpha_baseline = alpha_baseline
-        self.t1 = 1.0
-        self.t5 = 1.0
-        self.t15 = 1.0
+        self.t1 = initial
+        self.t5 = initial
+        self.t15 = initial
 
-    def update(self, score: float) -> tuple[float, float, float]:
-        """Update all three windows. Returns (t1, t5, t15)."""
-        self.t1 = self.t1 * (1 - self.alpha_short) + score * self.alpha_short
-        self.t5 = self.t5 * (1 - self.alpha_session) + score * self.alpha_session
-        self.t15 = self.t15 * (1 - self.alpha_baseline) + score * self.alpha_baseline
+    def update(self, score: float, allow_increase: bool = True) -> tuple[float, float, float]:
+        """Update all three windows. Returns (t1, t5, t15).
+
+        With ``allow_increase=False`` (self-reported evidence) each window
+        uses ``min(score, window)`` as the effective score, so the update can
+        only hold or lower trust — a subject asserting its own success gains
+        nothing, while claims against interest still count.
+        """
+        s1 = score if allow_increase else min(score, self.t1)
+        s5 = score if allow_increase else min(score, self.t5)
+        s15 = score if allow_increase else min(score, self.t15)
+        self.t1 = self.t1 * (1 - self.alpha_short) + s1 * self.alpha_short
+        self.t5 = self.t5 * (1 - self.alpha_session) + s5 * self.alpha_session
+        self.t15 = self.t15 * (1 - self.alpha_baseline) + s15 * self.alpha_baseline
         return (self.t1, self.t5, self.t15)
 
     def snapshot(self) -> TrustSnapshot:

--- a/src/agent_riggs/trust/gate.py
+++ b/src/agent_riggs/trust/gate.py
@@ -1,0 +1,127 @@
+"""Fail-closed trust gate.
+
+This is the enforcement point that consumes the verified trust ledger. It is
+invoked on every capability-expanding path:
+
+* ``agent-riggs gate`` (CLI, exit code contract for harness hooks)
+* the ``RiggsGate`` MCP tool
+* ratchet **tool promotions** (capability-expanding; constraint promotions
+  tighten and are never gated)
+* the LOOSEN recommendation published to ``.kibitzer/state.json``
+
+Deny conditions (fail closed — unknown never means trusted):
+
+* trust state absent → deny (a subject with no verified history is *low*
+  trust, not max)
+* trust state fails integrity verification → deny
+* short- or session-window trust below ``gate_threshold`` → deny
+* a failure-class event within the last ``violation_holdoff_turns`` records
+  → deny (a serious incident must not be washed out by a burst of successes)
+
+The gate loads its policy via :func:`agent_riggs.config.load_trusted_trust_config`,
+which ignores the subject-writable ``.riggs/config.toml``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from agent_riggs.config import TrustConfig, load_trusted_trust_config
+from agent_riggs.trust.ledger import LedgerState, TrustLedger
+
+#: Ledger record categories that count as violations for the holdoff window.
+VIOLATION_CATEGORIES = frozenset({"failure", "path_denial", "repeated_failure"})
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    allowed: bool
+    reason: str
+    trust_1: float
+    trust_5: float
+    trust_15: float
+    state: str  # ledger status: "ok" | "absent" | "tampered"
+
+
+def _deny(reason: str, state: LedgerState) -> GateDecision:
+    last = state.last
+    return GateDecision(
+        allowed=False,
+        reason=reason,
+        trust_1=last.t1 if last else 0.0,
+        trust_5=last.t5 if last else 0.0,
+        trust_15=last.t15 if last else 0.0,
+        state=state.status,
+    )
+
+
+def evaluate_gate(state: LedgerState, config: TrustConfig) -> GateDecision:
+    """Pure gate decision over a verified ledger state. Fail closed."""
+    if state.status == "tampered":
+        return GateDecision(
+            allowed=False,
+            reason=f"trust ledger failed integrity verification ({state.detail}); fail closed",
+            trust_1=0.0,
+            trust_5=0.0,
+            trust_15=0.0,
+            state=state.status,
+        )
+    if state.status != "ok" or not state.records:
+        return GateDecision(
+            allowed=False,
+            reason="no verified trust history; unknown subjects are low trust (fail closed)",
+            trust_1=0.0,
+            trust_5=0.0,
+            trust_15=0.0,
+            state=state.status,
+        )
+
+    last = state.records[-1]
+    if min(last.t1, last.t5) < config.gate_threshold:
+        return _deny(
+            f"trust below gate threshold: t1={last.t1:.2f}, t5={last.t5:.2f} "
+            f"< {config.gate_threshold}",
+            state,
+        )
+
+    holdoff = max(config.violation_holdoff_turns, 0)
+    if holdoff:
+        recent = state.records[-holdoff:]
+        violations = [r for r in recent if r.category in VIOLATION_CATEGORIES]
+        if violations:
+            return _deny(
+                f"{len(violations)} violation(s) within the last {holdoff} turns "
+                f"(most recent: {violations[-1].category})",
+                state,
+            )
+
+    return GateDecision(
+        allowed=True,
+        reason=(
+            f"verified trust t1={last.t1:.2f}, t5={last.t5:.2f} "
+            f"over {len(state.records)} turns"
+        ),
+        trust_1=last.t1,
+        trust_5=last.t5,
+        trust_15=last.t15,
+        state=state.status,
+    )
+
+
+class TrustGate:
+    """Loads verified trust state and applies the gate policy."""
+
+    def __init__(
+        self,
+        project_root: Path | str,
+        config: TrustConfig | None = None,
+        ledger: TrustLedger | None = None,
+    ) -> None:
+        self.project_root = Path(project_root)
+        # Policy comes from trusted sources only; never from the project tree.
+        self.config = config if config is not None else load_trusted_trust_config(project_root)
+        self.ledger = ledger if ledger is not None else TrustLedger(project_root)
+
+    def check(self) -> GateDecision:
+        return evaluate_gate(self.ledger.verify(), self.config)

--- a/src/agent_riggs/trust/ledger.py
+++ b/src/agent_riggs/trust/ledger.py
@@ -1,0 +1,249 @@
+"""Append-only, HMAC-chained trust ledger.
+
+The ledger is the authoritative record of trust state. It addresses three
+tamper paths (see the project's security advisory):
+
+* **rm-to-reset** — the ledger lives outside the project tree
+  (:mod:`agent_riggs.statedir`), so deleting ``.riggs/store.duckdb`` does
+  not touch it. Deleting the ledger itself reads as ``absent``, which
+  consumers must treat as *low* trust (fail closed), not max.
+* **direct edits** — every record carries an HMAC over its payload chained
+  to the previous record's MAC. Any edit breaks verification and the state
+  reads as ``tampered`` (fail closed).
+* **truncation** — a MAC'd head file pins the expected last record; cutting
+  trailing (low-trust) records without the key reads as ``tampered``.
+
+Known residual risk: an adversary who can read the key, or who snapshots
+the *entire* state directory at a high-trust moment and later restores it,
+defeats the chain. The key and ledger are created ``0600`` inside a ``0700``
+directory; deployments wanting a hard boundary must keep the state
+directory outside the subject's write (and ideally read) scope.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime
+from hashlib import sha256
+from pathlib import Path
+
+from agent_riggs.statedir import state_dir_for
+
+_GENESIS = "0" * 64
+
+_KEY_FILE = "ledger.key"
+_LEDGER_FILE = "trust-ledger.jsonl"
+_HEAD_FILE = "trust-ledger.head"
+
+_PAYLOAD_FIELDS = (
+    "seq",
+    "timestamp",
+    "session_id",
+    "event_uid",
+    "category",
+    "score",
+    "t1",
+    "t5",
+    "t15",
+    "observed",
+    "prev_mac",
+)
+
+
+class LedgerIntegrityError(Exception):
+    """Raised when an operation would run on top of unverifiable trust state."""
+
+
+@dataclass(frozen=True)
+class LedgerRecord:
+    seq: int
+    timestamp: str
+    session_id: str
+    event_uid: str
+    category: str
+    score: float
+    t1: float
+    t5: float
+    t15: float
+    observed: bool
+    prev_mac: str
+    mac: str
+
+
+@dataclass
+class LedgerState:
+    """Result of verifying the ledger. ``records`` is populated only for ``ok``."""
+
+    status: str  # "ok" | "absent" | "tampered"
+    records: list[LedgerRecord] = field(default_factory=list)
+    detail: str = ""
+
+    @property
+    def last(self) -> LedgerRecord | None:
+        return self.records[-1] if self.records else None
+
+
+def _canonical(payload: dict) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+class TrustLedger:
+    """Reads and appends the per-project trust ledger."""
+
+    def __init__(self, project_root: Path | str, state_dir: Path | None = None) -> None:
+        self.dir = Path(state_dir) if state_dir is not None else state_dir_for(project_root)
+        self.key_path = self.dir / _KEY_FILE
+        self.ledger_path = self.dir / _LEDGER_FILE
+        self.head_path = self.dir / _HEAD_FILE
+
+    # -- key handling ------------------------------------------------------
+
+    def ensure_initialized(self) -> None:
+        """Create the state directory and signing key if they don't exist."""
+        self._ensure_key()
+
+    def _ensure_key(self) -> bytes:
+        key = self._load_key()
+        if key is not None:
+            return key
+        self.dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.dir, 0o700)
+        key = secrets.token_bytes(32)
+        fd = os.open(self.key_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(fd, key.hex().encode())
+        finally:
+            os.close(fd)
+        return key
+
+    def _load_key(self) -> bytes | None:
+        try:
+            return bytes.fromhex(self.key_path.read_text().strip())
+        except FileNotFoundError:
+            return None
+        except ValueError:
+            return None  # corrupt key: treated as missing; verify() reports tampered
+
+    # -- mac helpers ---------------------------------------------------------
+
+    def _record_mac(self, key: bytes, payload: dict) -> str:
+        return hmac.new(key, _canonical(payload), sha256).hexdigest()
+
+    def _head_mac(self, key: bytes, seq: int, mac: str) -> str:
+        return hmac.new(key, f"head:{seq}:{mac}".encode(), sha256).hexdigest()
+
+    def _read_head(self, key: bytes) -> tuple[int, str] | None:
+        """Return (seq, mac) if the head file exists and its MAC verifies."""
+        try:
+            head = json.loads(self.head_path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+        seq, mac, head_mac = head.get("seq"), head.get("mac"), head.get("head_mac")
+        if not isinstance(seq, int) or not isinstance(mac, str) or not isinstance(head_mac, str):
+            return None
+        if not hmac.compare_digest(head_mac, self._head_mac(key, seq, mac)):
+            return None
+        return seq, mac
+
+    def _write_head(self, key: bytes, seq: int, mac: str) -> None:
+        payload = {"seq": seq, "mac": mac, "head_mac": self._head_mac(key, seq, mac)}
+        tmp = self.head_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload))
+        os.replace(tmp, self.head_path)
+
+    # -- public API ----------------------------------------------------------
+
+    def append(
+        self,
+        *,
+        event_uid: str,
+        session_id: str,
+        category: str,
+        score: float,
+        t1: float,
+        t5: float,
+        t15: float,
+        observed: bool,
+        timestamp: datetime,
+    ) -> LedgerRecord:
+        """Append one trust record, chained to the current head."""
+        key = self._ensure_key()
+        head = self._read_head(key)
+        if head is not None:
+            seq, prev_mac = head[0] + 1, head[1]
+        else:
+            seq, prev_mac = 1, _GENESIS
+
+        payload = {
+            "seq": seq,
+            "timestamp": timestamp.isoformat(),
+            "session_id": session_id,
+            "event_uid": event_uid,
+            "category": category,
+            "score": score,
+            "t1": t1,
+            "t5": t5,
+            "t15": t15,
+            "observed": observed,
+            "prev_mac": prev_mac,
+        }
+        mac = self._record_mac(key, payload)
+        record = LedgerRecord(mac=mac, **payload)
+
+        with self.ledger_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps({**payload, "mac": mac}) + "\n")
+        os.chmod(self.ledger_path, 0o600)
+        self._write_head(key, seq, mac)
+        return record
+
+    def verify(self) -> LedgerState:
+        """Verify the full chain. Any inconsistency reads as ``tampered``.
+
+        ``absent`` is returned only when neither ledger nor head exist —
+        a genuinely new project. Everything else that fails to verify is
+        ``tampered`` and must be treated as low trust by consumers.
+        """
+        ledger_exists = self.ledger_path.exists()
+        head_exists = self.head_path.exists()
+        if not ledger_exists and not head_exists:
+            return LedgerState(status="absent")
+
+        key = self._load_key()
+        if key is None:
+            return LedgerState(status="tampered", detail="trust state present but key missing")
+        head = self._read_head(key)
+        if head is None:
+            return LedgerState(status="tampered", detail="head record missing or forged")
+        if not ledger_exists:
+            return LedgerState(status="tampered", detail="head present but ledger missing")
+
+        records: list[LedgerRecord] = []
+        prev_mac = _GENESIS
+        with self.ledger_path.open(encoding="utf-8") as f:
+            for i, line in enumerate(f):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                    payload = {name: obj[name] for name in _PAYLOAD_FIELDS}
+                    mac = obj["mac"]
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    return LedgerState(status="tampered", detail=f"unreadable record {i + 1}")
+                if payload["seq"] != len(records) + 1 or payload["prev_mac"] != prev_mac:
+                    return LedgerState(status="tampered", detail=f"broken chain at record {i + 1}")
+                if not hmac.compare_digest(mac, self._record_mac(key, payload)):
+                    return LedgerState(status="tampered", detail=f"bad MAC at record {i + 1}")
+                records.append(LedgerRecord(mac=mac, **payload))
+                prev_mac = mac
+
+        if not records:
+            return LedgerState(status="tampered", detail="empty ledger with head present")
+        last = records[-1]
+        if last.seq != head[0] or not hmac.compare_digest(last.mac, head[1]):
+            return LedgerState(status="tampered", detail="ledger truncated or rolled back")
+        return LedgerState(status="ok", records=records)

--- a/src/agent_riggs/trust/transitions.py
+++ b/src/agent_riggs/trust/transitions.py
@@ -27,12 +27,17 @@ def recommend_transition(
     t1: float,
     t5: float,
     t15: float,
-    turn_count: int,
+    sustained_high_turns: int,
     config: TrustConfig,
 ) -> Recommendation | None:
     """Evaluate trust state and return a recommendation, or None if healthy.
 
     Rules are evaluated in priority order (most urgent first).
+
+    ``sustained_high_turns`` is the number of *consecutive trailing* turns
+    with trust above the loosen threshold — not total elapsed turns. A late
+    burst of successes in a long session must not satisfy "sustained".
+    Callers derive it from the verified ledger.
     """
     # Auto-tighten: both short and session windows are bad
     if t1 < config.tighten_threshold and t5 < config.auto_tighten_threshold:
@@ -63,15 +68,18 @@ def recommend_transition(
             trust_5=t5,
         )
 
-    # Loosen: sustained high trust
+    # Loosen: trust held above threshold for N consecutive turns
     if (
         t1 > config.loosen_threshold
         and t5 > config.loosen_threshold - 0.1
-        and turn_count >= config.loosen_sustained_turns
+        and sustained_high_turns >= config.loosen_sustained_turns
     ):
         return Recommendation(
             action=TransitionAction.LOOSEN,
-            reason=f"trust_1={t1:.2f} and trust_5={t5:.2f} sustained for {turn_count} turns",
+            reason=(
+                f"trust_1={t1:.2f} and trust_5={t5:.2f} sustained for "
+                f"{sustained_high_turns} consecutive turns"
+            ),
             trust_1=t1,
             trust_5=t5,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,20 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Point the out-of-tree trust state directory at a per-test temp dir.
+
+    Trust state (ledger + key) lives outside the project tree; tests must
+    never read or write the developer's real state directory.
+    """
+    state_dir = tmp_path_factory.mktemp("riggs-state")
+    monkeypatch.setenv("AGENT_RIGGS_STATE_DIR", str(state_dir))
+    return state_dir
+
+
 @pytest.fixture
 def tmp_project(tmp_path: Path) -> Path:
     """A temporary project directory with .riggs/ created."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,12 +12,37 @@ def test_load_defaults_when_no_user_config(tmp_project: Path) -> None:
     assert config.store.path == ".riggs/store.duckdb"
 
 
-def test_user_config_overrides_defaults(tmp_project: Path) -> None:
+def test_user_config_overrides_non_trust_sections(tmp_project: Path) -> None:
     user_config = tmp_project / ".riggs" / "config.toml"
-    user_config.write_text("[trust]\nscore_success = 0.9\n")
+    user_config.write_text('[ratchet]\nmin_frequency = 9\n\n[store]\npath = "custom.duckdb"\n')
     config = load_config(tmp_project)
-    assert config.trust.score_success == 0.9
-    # Other defaults preserved
+    assert config.ratchet.min_frequency == 9
+    assert config.store.path == "custom.duckdb"
+
+
+def test_project_config_cannot_override_trust_policy(tmp_project: Path) -> None:
+    """[trust] in the subject-writable project config must be ignored.
+
+    Otherwise the scored subject could weaken its own scoring and gate
+    thresholds (GHSA hardening).
+    """
+    user_config = tmp_project / ".riggs" / "config.toml"
+    user_config.write_text("[trust]\nscore_failure = 1.0\ngate_threshold = 0.0\n")
+    config = load_config(tmp_project)
+    assert config.trust.score_failure == 0.2  # shipped default, not 1.0
+    assert config.trust.gate_threshold == 0.5
+
+
+def test_state_dir_policy_overrides_trust_policy(tmp_project: Path) -> None:
+    """policy.toml in the out-of-tree state dir is the trusted override path."""
+    from agent_riggs.statedir import state_dir_for
+
+    state_dir = state_dir_for(tmp_project)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "policy.toml").write_text("[trust]\ngate_threshold = 0.7\n")
+    config = load_config(tmp_project)
+    assert config.trust.gate_threshold == 0.7
+    # Untouched values keep their defaults
     assert config.trust.alpha_short == 0.4
 
 

--- a/tests/test_ingest/test_pipeline.py
+++ b/tests/test_ingest/test_pipeline.py
@@ -59,6 +59,11 @@ def test_ingest_stores_turns(tmp_project: Path) -> None:
 
 
 def test_ingest_computes_trust_scores(tmp_project: Path) -> None:
+    """Self-reported kibitzer successes are recorded but cannot inflate trust.
+
+    An unknown subject starts at ``initial_trust`` and self-reported success
+    holds trust at most where it is (GHSA: self-report must not raise trust).
+    """
     _setup_kibitzer(tmp_project)
     config = load_config(tmp_project)
     db_path = tmp_project / ".riggs" / "store.duckdb"
@@ -79,9 +84,36 @@ def test_ingest_computes_trust_scores(tmp_project: Path) -> None:
             "SELECT trust_1, trust_5, trust_15 FROM turns ORDER BY turn_number DESC LIMIT 1"
         ).fetchone()
         assert row is not None
-        assert row[0] > 0.9
-        assert row[1] > 0.9
-        assert row[2] > 0.9
+        assert row[0] <= config.trust.initial_trust + 1e-9
+        assert row[1] <= config.trust.initial_trust + 1e-9
+        assert row[2] <= config.trust.initial_trust + 1e-9
+
+
+def test_ingest_skips_malformed_log_lines(tmp_project: Path) -> None:
+    """One malformed subject-controlled line must not abort the whole ingest."""
+    _setup_kibitzer(tmp_project)
+    with (tmp_project / ".kibitzer" / "intercept.log").open("a") as f:
+        f.write("{not valid json\n")
+        f.write(
+            json.dumps({"timestamp": "2026-03-29T10:10:00Z", "tool": "Edit", "success": False})
+            + "\n"
+        )
+
+    config = load_config(tmp_project)
+    db_path = tmp_project / ".riggs" / "store.duckdb"
+
+    with Store(db_path) as store:
+        from agent_riggs.plugins.trust import TRUST_DDL
+
+        store.ensure_schema(TRUST_DDL)
+
+        result = ingest(
+            store=store,
+            project_root=tmp_project,
+            sources=[KibitzerSource()],
+            trust_config=config.trust,
+        )
+        assert result.turns_ingested == 4  # 3 valid + 1 after the bad line
 
 
 def test_ingest_skips_missing_sources(tmp_project: Path) -> None:

--- a/tests/test_ratchet/test_candidates.py
+++ b/tests/test_ratchet/test_candidates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from agent_riggs.config import RatchetConfig
 from agent_riggs.plugins.trust import TRUST_DDL
@@ -27,7 +27,8 @@ def _seed_failures(
                 _failure_id_seq + 10000,
                 session,
                 project,
-                datetime(2026, 3, 29, 10, 0, 0, tzinfo=UTC),
+                # Relative to now: a fixed date rots out of the lookback window.
+                datetime.now(UTC) - timedelta(days=1),
                 category,
                 tool,
                 mode,

--- a/tests/test_trust/test_gate.py
+++ b/tests/test_trust/test_gate.py
@@ -1,0 +1,95 @@
+"""Unit tests for the fail-closed trust gate.
+
+The gate is the enforcement point that consumes the verified trust ledger.
+It must deny on: absent state, tampered state, insufficient trust, and
+recent violations — and only allow on verified, sufficient, clean history.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from agent_riggs.config import TrustConfig
+from agent_riggs.trust.gate import TrustGate, evaluate_gate
+from agent_riggs.trust.ledger import LedgerState, TrustLedger
+
+
+def _record_state(
+    ledger: TrustLedger,
+    trusts: list[float],
+    categories: list[str] | None = None,
+) -> LedgerState:
+    cats = categories or ["success"] * len(trusts)
+    for i, (t, cat) in enumerate(zip(trusts, cats, strict=True)):
+        ledger.append(
+            event_uid=f"g:{i}",
+            session_id="sess-1",
+            category=cat,
+            score=1.0 if cat == "success" else 0.2,
+            t1=t,
+            t5=t,
+            t15=t,
+            observed=True,
+            timestamp=datetime(2026, 6, 1, 10, i % 60, tzinfo=UTC),
+        )
+    return ledger.verify()
+
+
+def test_evaluate_denies_absent_state() -> None:
+    decision = evaluate_gate(LedgerState(status="absent"), TrustConfig())
+    assert decision.allowed is False
+    assert decision.trust_1 == 0.0
+
+
+def test_evaluate_denies_tampered_state() -> None:
+    decision = evaluate_gate(LedgerState(status="tampered", detail="mac mismatch"), TrustConfig())
+    assert decision.allowed is False
+    assert "integrity" in decision.reason.lower() or "tamper" in decision.reason.lower()
+
+
+def test_evaluate_denies_low_trust(tmp_project: Path) -> None:
+    state = _record_state(TrustLedger(tmp_project), [0.9, 0.7, 0.4])
+    decision = evaluate_gate(state, TrustConfig())
+    assert decision.allowed is False
+
+
+def test_evaluate_allows_verified_high_trust(tmp_project: Path) -> None:
+    state = _record_state(TrustLedger(tmp_project), [0.7, 0.8, 0.9])
+    decision = evaluate_gate(state, TrustConfig())
+    assert decision.allowed is True
+
+
+def test_evaluate_denies_recent_violation(tmp_project: Path) -> None:
+    """A serious incident must be sticky: high EWMA alone doesn't reopen the gate."""
+    trusts = [0.9] * 10
+    cats = ["success"] * 10
+    cats[7] = "failure"  # violation 3 records ago, within the holdoff window
+    state = _record_state(TrustLedger(tmp_project), trusts, cats)
+    decision = evaluate_gate(state, TrustConfig(violation_holdoff_turns=5))
+    assert decision.allowed is False
+
+
+def test_evaluate_violation_outside_holdoff_ok(tmp_project: Path) -> None:
+    trusts = [0.9] * 10
+    cats = ["success"] * 10
+    cats[1] = "failure"  # long since past
+    state = _record_state(TrustLedger(tmp_project), trusts, cats)
+    decision = evaluate_gate(state, TrustConfig(violation_holdoff_turns=5))
+    assert decision.allowed is True
+
+
+def test_gate_check_fail_closed_on_missing_state(tmp_project: Path) -> None:
+    decision = TrustGate(tmp_project).check()
+    assert decision.allowed is False
+
+
+def test_gate_check_fail_closed_on_tamper(tmp_project: Path) -> None:
+    ledger = TrustLedger(tmp_project)
+    _record_state(ledger, [0.9] * 5)
+    # Flip a byte in the ledger.
+    raw = ledger.ledger_path.read_bytes()
+    ledger.ledger_path.write_bytes(raw.replace(b'"t1": 0.9', b'"t1": 1.0'))
+
+    decision = TrustGate(tmp_project).check()
+    assert decision.allowed is False

--- a/tests/test_trust/test_gate_wiring.py
+++ b/tests/test_trust/test_gate_wiring.py
@@ -1,0 +1,157 @@
+"""The gate must actually be invoked on enforcement paths (not just defined).
+
+On the vulnerable code the transition logic was dead code referenced only by
+tests, and nothing consumed trust before a capability-expanding action.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from agent_riggs.assembly import assemble
+from agent_riggs.cli import main
+
+
+def _seed_tool_candidate(project: Path) -> None:
+    """Seed turns rows that produce a tool_promotion (capability-expanding) candidate."""
+    service = assemble(project)
+    base = datetime.now(UTC) - timedelta(days=1)
+    for i in range(6):
+        service.store.execute(
+            """INSERT INTO turns (turn_id, session_id, project, turn_number, timestamp,
+                   tool_name, tool_success, mode, trust_score, trust_1, trust_5, trust_15,
+                   event_category, metadata)
+               VALUES (?, ?, ?, ?, ?, 'Bash', true, 'implement', 1.0, 0.9, 0.9, 0.9,
+                       'success', ?)""",
+            [
+                50000 + i,
+                f"sess-{i % 3}",
+                project.name,
+                i,
+                base + timedelta(minutes=i),
+                json.dumps({"command": "pytest tests/"}),
+            ],
+        )
+    service.store.close()
+
+
+def _accrue_observed_trust(project: Path, n: int = 40) -> None:
+    bird = project / ".bird"
+    bird.mkdir(exist_ok=True)
+    conn = duckdb.connect(str(bird / "blq.duckdb"))
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS invocations (
+            id INTEGER, session_id VARCHAR, timestamp TIMESTAMP, cmd VARCHAR,
+            executable VARCHAR, exit_code INTEGER, duration_ms INTEGER, source_name VARCHAR
+        )"""
+    )
+    base = datetime(2026, 6, 2, 9, 0)
+    for i in range(n):
+        conn.execute(
+            "INSERT INTO invocations VALUES (?, ?, ?, ?, ?, 0, 100, 'test')",
+            [i + 1, "sess-blq", base + timedelta(minutes=i), "pytest", "pytest"],
+        )
+    conn.close()
+
+    from agent_riggs.config import load_config
+    from agent_riggs.ingest.pipeline import ingest
+    from agent_riggs.ingest.sources.blq import BlqSource
+    from agent_riggs.plugins.trust import TRUST_DDL
+    from agent_riggs.store import Store
+
+    config = load_config(project)
+    with Store(project / ".riggs" / "store.duckdb") as store:
+        store.ensure_schema(TRUST_DDL)
+        ingest(store=store, project_root=project, sources=[BlqSource()], trust_config=config.trust)
+
+
+def test_promote_tool_candidate_denied_without_verified_trust(tmp_project: Path) -> None:
+    _seed_tool_candidate(tmp_project)
+    service = assemble(tmp_project)
+    try:
+        ratchet = service.plugin("ratchet")
+        candidates = ratchet.candidates()
+        keys = [c.candidate_key for c in candidates if c.candidate_type == "tool_promotion"]
+        assert keys, "expected a tool_promotion candidate"
+
+        with pytest.raises(PermissionError):
+            ratchet.promote(keys[0])
+
+        row = service.store.execute("SELECT count(*) FROM ratchet_decisions").fetchone()
+        assert row == (0,), "denied promotion must not be recorded"
+    finally:
+        service.store.close()
+
+
+def test_promote_tool_candidate_allowed_with_verified_trust(tmp_project: Path) -> None:
+    _accrue_observed_trust(tmp_project)
+    _seed_tool_candidate(tmp_project)
+    service = assemble(tmp_project)
+    try:
+        ratchet = service.plugin("ratchet")
+        keys = [
+            c.candidate_key for c in ratchet.candidates() if c.candidate_type == "tool_promotion"
+        ]
+        assert keys
+        ratchet.promote(keys[0], reason="verified trust")
+        row = service.store.execute("SELECT count(*) FROM ratchet_decisions").fetchone()
+        assert row == (1,)
+    finally:
+        service.store.close()
+
+
+def test_cli_gate_denies_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["init"])
+    result = runner.invoke(main, ["gate"])
+    assert result.exit_code == 2
+    assert "deny" in result.output.lower()
+
+
+def test_cli_gate_allows_after_accrual(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["init"])
+    _accrue_observed_trust(tmp_path)
+    result = runner.invoke(main, ["gate"])
+    assert result.exit_code == 0
+    assert "allow" in result.output.lower()
+
+
+def test_ingest_publishes_recommendation_to_kibitzer_state(tmp_project: Path) -> None:
+    """README's documented loop: recommendations land in .kibitzer/state.json."""
+    kib = tmp_project / ".kibitzer"
+    kib.mkdir()
+    (kib / "state.json").write_text(json.dumps({"mode": "implement", "session_id": "s1"}))
+    with (kib / "intercept.log").open("w") as f:
+        for i in range(5):
+            f.write(
+                json.dumps(
+                    {
+                        "timestamp": f"2026-06-01T10:0{i}:00Z",
+                        "tool": "Edit",
+                        "success": False,
+                    }
+                )
+                + "\n"
+            )
+
+    service = assemble(tmp_project)
+    try:
+        service.plugin("ingest").run()
+    finally:
+        service.store.close()
+
+    state = json.loads((kib / "state.json").read_text())
+    assert "riggs" in state, "ingest must publish trust info for kibitzer"
+    riggs = state["riggs"]
+    assert riggs["gate"]["allowed"] is False
+    assert riggs["recommendation"] is not None
+    assert "tighten" in riggs["recommendation"]["action"]

--- a/tests/test_trust/test_integrity.py
+++ b/tests/test_trust/test_integrity.py
@@ -1,0 +1,265 @@
+"""Regression tests: the scored subject must not be able to elevate its own trust.
+
+These reproduce the tamper paths from the private security advisory
+GHSA-j5cw-vqqp-pmm5 and FAIL on the vulnerable code:
+
+1. rm-to-reset: deleting ``.riggs/store.duckdb`` must not restore trust.
+2. Direct edit: a subject-forged max-trust row in the store must not be
+   believed.
+3. Self-report: a session appending its own ``success`` entries must not be
+   able to raise its trust/EWMA.
+4. Replay: re-ingesting the same evidence must not re-count it.
+
+Note on the ownership boundary: real filesystem-permission separation
+(separate uid owning the state directory) is not practical in CI. The
+boundary is simulated by an out-of-tree state directory
+(``AGENT_RIGGS_STATE_DIR``), and the always-run guards for the
+score-derivation and gate decision are the pure unit tests in
+``test_ledger.py`` and ``test_gate.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+from agent_riggs.assembly import assemble
+from agent_riggs.config import load_config
+from agent_riggs.ingest.pipeline import ingest
+from agent_riggs.ingest.sources.blq import BlqSource
+from agent_riggs.ingest.sources.kibitzer import KibitzerSource
+from agent_riggs.plugins.trust import TRUST_DDL
+from agent_riggs.store import Store
+
+LOW_TRUST = 0.5  # anything at/above this would satisfy the default gate
+
+
+def _write_kibitzer_log(
+    project: Path, entries: list[dict[str, Any]], append: bool = False
+) -> None:
+    kib_dir = project / ".kibitzer"
+    kib_dir.mkdir(exist_ok=True)
+    state_path = kib_dir / "state.json"
+    if not state_path.exists():
+        state_path.write_text(json.dumps({"mode": "implement", "session_id": "sess-subject"}))
+    mode = "a" if append else "w"
+    with (kib_dir / "intercept.log").open(mode) as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+def _failure_entries(n: int, start: int = 0) -> list[dict[str, Any]]:
+    base = datetime(2026, 6, 1, 10, 0, tzinfo=UTC)
+    return [
+        {
+            "timestamp": (base + timedelta(minutes=start + i)).isoformat(),
+            "tool": "Edit",
+            "success": False,
+            "error": "old_string not found",
+        }
+        for i in range(n)
+    ]
+
+
+def _success_entries(n: int, start: int = 0) -> list[dict[str, Any]]:
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    return [
+        {
+            "timestamp": (base + timedelta(minutes=start + i)).isoformat(),
+            "tool": "Read",
+            "success": True,
+        }
+        for i in range(n)
+    ]
+
+
+def _write_blq_db(project: Path, exit_codes: list[int]) -> None:
+    """Create a .bird/blq.duckdb with observed invocation outcomes."""
+    bird = project / ".bird"
+    bird.mkdir(exist_ok=True)
+    db = bird / "blq.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS invocations (
+            id INTEGER, session_id VARCHAR, timestamp TIMESTAMP, cmd VARCHAR,
+            executable VARCHAR, exit_code INTEGER, duration_ms INTEGER, source_name VARCHAR
+        )"""
+    )
+    row = conn.execute("SELECT coalesce(max(id), 0) FROM invocations").fetchone()
+    next_id = (row[0] if row else 0) + 1
+    base = datetime(2026, 6, 2, 9, 0)
+    for i, code in enumerate(exit_codes):
+        conn.execute(
+            "INSERT INTO invocations VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [next_id + i, "sess-blq", base + timedelta(minutes=i), "pytest", "pytest", code, 100,
+             "test"],
+        )
+    conn.close()
+
+
+def _ingest(project: Path, sources: list[Any]) -> Any:
+    config = load_config(project)
+    with Store(project / ".riggs" / "store.duckdb") as store:
+        store.ensure_schema(TRUST_DDL)
+        return ingest(
+            store=store,
+            project_root=project,
+            sources=sources,
+            trust_config=config.trust,
+        )
+
+
+def _current_trust(project: Path) -> dict[str, Any]:
+    service = assemble(project)
+    try:
+        return service.plugin("trust").current()
+    finally:
+        service.store.close()
+
+
+def test_deleting_store_does_not_restore_trust(tmp_project: Path) -> None:
+    """Advisory path 1: `rm .riggs/store.duckdb` must not reset trust to max."""
+    _write_kibitzer_log(tmp_project, _failure_entries(10))
+    _ingest(tmp_project, [KibitzerSource()])
+
+    before = _current_trust(tmp_project)
+    assert before["trust_1"] < LOW_TRUST  # sanity: repeated failures = low trust
+
+    # The scored subject deletes the store in its own project tree.
+    (tmp_project / ".riggs" / "store.duckdb").unlink()
+
+    after = _current_trust(tmp_project)
+    assert after["trust_1"] < LOW_TRUST, "deleting the store must not restore trust"
+    assert after["trust_1"] <= before["trust_1"] + 1e-9
+
+
+def test_direct_store_edit_cannot_raise_trust(tmp_project: Path) -> None:
+    """Advisory path 1b: a forged max-trust row in the store must not be believed."""
+    _write_kibitzer_log(tmp_project, _failure_entries(10))
+    _ingest(tmp_project, [KibitzerSource()])
+
+    before = _current_trust(tmp_project)
+    assert before["trust_1"] < LOW_TRUST
+
+    # The subject opens its own read-write connection and forges max trust.
+    conn = duckdb.connect(str(tmp_project / ".riggs" / "store.duckdb"))
+    conn.execute(
+        """INSERT INTO turns (turn_id, session_id, project, turn_number, timestamp,
+               tool_name, tool_success, mode, trust_score, trust_1, trust_5, trust_15,
+               event_category, metadata)
+           VALUES (999999, 'forged', ?, 999, now(), 'Bash', true, 'implement',
+                   1.0, 1.0, 1.0, 1.0, 'success', '{}')""",
+        [tmp_project.name],
+    )
+    conn.close()
+
+    after = _current_trust(tmp_project)
+    assert after["trust_1"] < LOW_TRUST, "a subject-written store row must not raise trust"
+    assert after["trust_1"] <= before["trust_1"] + 1e-9
+
+
+def test_self_reported_success_cannot_raise_trust(tmp_project: Path) -> None:
+    """Advisory path 2: self-reported `success` entries must not raise trust/EWMA."""
+    _write_kibitzer_log(tmp_project, _failure_entries(5))
+    _ingest(tmp_project, [KibitzerSource()])
+
+    before = _current_trust(tmp_project)
+    assert before["trust_1"] < LOW_TRUST
+
+    # The subject appends 50 self-reported successes to its own log.
+    _write_kibitzer_log(tmp_project, _success_entries(50, start=100), append=True)
+    _ingest(tmp_project, [KibitzerSource()])
+
+    after = _current_trust(tmp_project)
+    assert after["trust_1"] <= before["trust_1"] + 1e-9, (
+        "self-reported success must not raise trust "
+        f"(before={before['trust_1']:.3f}, after={after['trust_1']:.3f})"
+    )
+    assert after["trust_5"] <= before["trust_5"] + 1e-9
+    assert after["trust_15"] <= before["trust_15"] + 1e-9
+
+
+def test_self_reported_failure_still_lowers_trust(tmp_project: Path) -> None:
+    """Asymmetry check: claims against interest are still counted."""
+    _write_blq_db(tmp_project, exit_codes=[0] * 20)
+    _ingest(tmp_project, [BlqSource()])
+    before = _current_trust(tmp_project)
+
+    _write_kibitzer_log(tmp_project, _failure_entries(3, start=500))
+    _ingest(tmp_project, [KibitzerSource()])
+    after = _current_trust(tmp_project)
+
+    assert after["trust_1"] < before["trust_1"]
+
+
+def test_reingesting_same_evidence_is_idempotent(tmp_project: Path) -> None:
+    """Replaying `ingest` over the same evidence must not re-count it."""
+    _write_blq_db(tmp_project, exit_codes=[0] * 5)
+    first = _ingest(tmp_project, [BlqSource()])
+    assert first.turns_ingested == 5
+
+    trust_after_first = _current_trust(tmp_project)
+
+    second = _ingest(tmp_project, [BlqSource()])
+    assert second.turns_ingested == 0, "re-ingest must not duplicate already-counted events"
+
+    trust_after_second = _current_trust(tmp_project)
+    assert abs(trust_after_second["trust_5"] - trust_after_first["trust_5"]) < 1e-9
+
+
+def test_observed_success_still_accrues_trust(tmp_project: Path) -> None:
+    """Legitimate accrual: independently observed outcomes raise trust."""
+    _write_blq_db(tmp_project, exit_codes=[0] * 40)
+    _ingest(tmp_project, [BlqSource()])
+
+    current = _current_trust(tmp_project)
+    assert current["has_data"] is True
+    assert current["trust_1"] > 0.9
+    assert current["trust_5"] > 0.8
+
+
+def test_gate_denies_unknown_subject(tmp_project: Path) -> None:
+    """Advisory path 3: absent trust state must read as LOW trust, gate denies."""
+    from agent_riggs.trust.gate import TrustGate
+
+    decision = TrustGate(tmp_project).check()
+    assert decision.allowed is False
+    assert decision.trust_1 < LOW_TRUST
+
+
+def test_gate_allows_after_observed_accrual(tmp_project: Path) -> None:
+    """A well-behaved subject with verified observed history passes the gate."""
+    from agent_riggs.trust.gate import TrustGate
+
+    _write_blq_db(tmp_project, exit_codes=[0] * 40)
+    _ingest(tmp_project, [BlqSource()])
+
+    decision = TrustGate(tmp_project).check()
+    assert decision.allowed is True
+
+
+def test_subject_config_cannot_weaken_gate(tmp_project: Path) -> None:
+    """The subject-writable .riggs/config.toml must not weaken gate/scoring policy."""
+    from agent_riggs.trust.gate import TrustGate
+
+    (tmp_project / ".riggs" / "config.toml").write_text(
+        "[trust]\n"
+        "gate_threshold = 0.0\n"
+        "initial_trust = 1.0\n"
+        "score_failure = 1.0\n"
+        "score_repeated_failure = 1.0\n"
+    )
+
+    # Gate must still deny a subject with no verified history.
+    decision = TrustGate(tmp_project).check()
+    assert decision.allowed is False
+
+    # And failures must still score as failures during ingest.
+    _write_kibitzer_log(tmp_project, _failure_entries(10))
+    _ingest(tmp_project, [KibitzerSource()])
+    current = _current_trust(tmp_project)
+    assert current["trust_1"] < LOW_TRUST

--- a/tests/test_trust/test_ledger.py
+++ b/tests/test_trust/test_ledger.py
@@ -1,0 +1,136 @@
+"""Unit tests for the HMAC-chained, out-of-tree trust ledger.
+
+These are the always-run guards for store integrity: tampering with the
+ledger in any way (edit, truncate, delete the key) must be detected and
+read as an unverifiable — i.e. untrusted — state.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from agent_riggs.trust.ledger import TrustLedger
+
+
+def _append_n(ledger: TrustLedger, n: int, t1: float = 0.9) -> None:
+    for i in range(n):
+        ledger.append(
+            event_uid=f"test:{i}",
+            session_id="sess-1",
+            category="success",
+            score=1.0,
+            t1=t1,
+            t5=t1,
+            t15=t1,
+            observed=True,
+            timestamp=datetime(2026, 6, 1, 10, i % 60, tzinfo=UTC),
+        )
+
+
+def test_roundtrip_verifies_ok(tmp_project: Path) -> None:
+    ledger = TrustLedger(tmp_project)
+    _append_n(ledger, 5)
+
+    state = TrustLedger(tmp_project).verify()
+    assert state.status == "ok"
+    assert len(state.records) == 5
+    assert state.last is not None
+    assert state.last.seq == 5
+    assert state.last.t1 == 0.9
+
+
+def test_absent_state_reports_absent(tmp_project: Path) -> None:
+    state = TrustLedger(tmp_project).verify()
+    assert state.status == "absent"
+    assert state.records == []
+
+
+def test_edited_record_is_tampered(tmp_project: Path) -> None:
+    ledger = TrustLedger(tmp_project)
+    _append_n(ledger, 5, t1=0.2)
+
+    # The subject rewrites a record to claim max trust.
+    lines = ledger.ledger_path.read_text().splitlines()
+    record = json.loads(lines[-1])
+    record["t1"] = record["t5"] = record["t15"] = 1.0
+    lines[-1] = json.dumps(record)
+    ledger.ledger_path.write_text("\n".join(lines) + "\n")
+
+    state = TrustLedger(tmp_project).verify()
+    assert state.status == "tampered"
+
+
+def test_truncated_ledger_is_tampered(tmp_project: Path) -> None:
+    ledger = TrustLedger(tmp_project)
+    _append_n(ledger, 3, t1=0.9)
+    # Trust drops; the subject then truncates the trailing low-trust records.
+    ledger.append(
+        event_uid="test:fail",
+        session_id="sess-1",
+        category="failure",
+        score=0.2,
+        t1=0.2,
+        t5=0.5,
+        t15=0.8,
+        observed=True,
+        timestamp=datetime(2026, 6, 1, 11, 0, tzinfo=UTC),
+    )
+
+    lines = ledger.ledger_path.read_text().splitlines()
+    ledger.ledger_path.write_text("\n".join(lines[:-1]) + "\n")
+
+    state = TrustLedger(tmp_project).verify()
+    assert state.status == "tampered"
+
+
+def test_missing_key_is_tampered(tmp_project: Path) -> None:
+    ledger = TrustLedger(tmp_project)
+    _append_n(ledger, 2)
+    ledger.key_path.unlink()
+
+    state = TrustLedger(tmp_project).verify()
+    assert state.status == "tampered"
+
+
+def test_forged_head_is_tampered(tmp_project: Path) -> None:
+    """A head file rewritten to point at an earlier (higher-trust) record fails."""
+    ledger = TrustLedger(tmp_project)
+    _append_n(ledger, 2, t1=0.95)
+    ledger.append(
+        event_uid="test:fail",
+        session_id="sess-1",
+        category="failure",
+        score=0.2,
+        t1=0.2,
+        t5=0.4,
+        t15=0.7,
+        observed=True,
+        timestamp=datetime(2026, 6, 1, 11, 0, tzinfo=UTC),
+    )
+
+    lines = ledger.ledger_path.read_text().splitlines()
+    second = json.loads(lines[1])
+    # Forge a head pointing at record 2 (no key, so no valid head MAC).
+    ledger.head_path.write_text(
+        json.dumps({"seq": second["seq"], "mac": second["mac"], "head_mac": "0" * 64})
+    )
+    ledger.ledger_path.write_text("\n".join(lines[:2]) + "\n")
+
+    state = TrustLedger(tmp_project).verify()
+    assert state.status == "tampered"
+
+
+def test_ledger_lives_outside_project_tree(tmp_project: Path) -> None:
+    ledger = TrustLedger(tmp_project)
+    _append_n(ledger, 1)
+    assert not ledger.ledger_path.is_relative_to(tmp_project)
+    assert not ledger.key_path.is_relative_to(tmp_project)
+
+
+def test_key_file_permissions(tmp_project: Path) -> None:
+    ledger = TrustLedger(tmp_project)
+    _append_n(ledger, 1)
+    mode = ledger.key_path.stat().st_mode & 0o777
+    assert mode == 0o600

--- a/tests/test_trust/test_transitions.py
+++ b/tests/test_trust/test_transitions.py
@@ -9,39 +9,49 @@ from agent_riggs.trust.transitions import (
 
 def test_no_recommendation_when_healthy() -> None:
     config = TrustConfig()
-    result = recommend_transition(t1=0.9, t5=0.8, t15=0.85, turn_count=10, config=config)
+    result = recommend_transition(t1=0.9, t5=0.8, t15=0.85, sustained_high_turns=10, config=config)
     assert result is None
 
 
 def test_recommend_tighten_when_t1_low() -> None:
     config = TrustConfig()
-    result = recommend_transition(t1=0.2, t5=0.6, t15=0.8, turn_count=10, config=config)
+    result = recommend_transition(t1=0.2, t5=0.6, t15=0.8, sustained_high_turns=0, config=config)
     assert result is not None
     assert result.action == TransitionAction.TIGHTEN
 
 
 def test_auto_tighten_when_both_low() -> None:
     config = TrustConfig()
-    result = recommend_transition(t1=0.2, t5=0.4, t15=0.7, turn_count=10, config=config)
+    result = recommend_transition(t1=0.2, t5=0.4, t15=0.7, sustained_high_turns=0, config=config)
     assert result is not None
     assert result.action == TransitionAction.AUTO_TIGHTEN
 
 
 def test_suggest_loosen_when_sustained_high() -> None:
     config = TrustConfig()
-    result = recommend_transition(t1=0.95, t5=0.85, t15=0.9, turn_count=25, config=config)
+    result = recommend_transition(
+        t1=0.95, t5=0.85, t15=0.9, sustained_high_turns=25, config=config
+    )
     assert result is not None
     assert result.action == TransitionAction.LOOSEN
 
 
 def test_no_loosen_if_not_sustained() -> None:
+    """High trust for only a few consecutive turns must not loosen.
+
+    Issue #3: "sustained" means trust held high for N consecutive trailing
+    turns, not N total elapsed turns — a late burst in a long session does
+    not qualify.
+    """
     config = TrustConfig()
-    result = recommend_transition(t1=0.95, t5=0.85, t15=0.9, turn_count=10, config=config)
+    result = recommend_transition(
+        t1=0.95, t5=0.85, t15=0.9, sustained_high_turns=10, config=config
+    )
     assert result is None
 
 
 def test_flag_project_when_baseline_low() -> None:
     config = TrustConfig()
-    result = recommend_transition(t1=0.8, t5=0.6, t15=0.4, turn_count=10, config=config)
+    result = recommend_transition(t1=0.8, t5=0.6, t15=0.4, sustained_high_turns=0, config=config)
     assert result is not None
     assert result.action == TransitionAction.FLAG_PROJECT


### PR DESCRIPTION
## Summary

Hardens the trust engine so the scored session cannot influence its own trust score through any in-band path, and wires up a real, fail-closed enforcement gate. Addresses the private security advisory **GHSA-j5cw-vqqp-pmm5** (details intentionally not spelled out here; advisory to be published at release) and the correctness/docs items in #3.

### What changed

- **Trust ledger.** Authoritative trust state now lives in an append-only, HMAC-chained ledger in an out-of-tree state directory (`AGENT_RIGGS_STATE_DIR` → `$XDG_STATE_HOME/agent-riggs` → `~/.local/state/agent-riggs`), keyed by the resolved project path. The project-local `.riggs/store.duckdb` is analytics only. Absent or unverifiable state reads as **low** trust — fail closed, never max.
- **Provenance-aware scoring.** Events are OBSERVED (independently recorded outcomes, e.g. blq exit codes — may raise trust) or SELF_REPORTED (kibitzer/lackpy/fledgling logs — per-window min-capped EWMA update, so they can hold or lower trust but never raise it). Unknown subjects seed at a low `initial_trust` (0.4) and must accrue trust from observed evidence.
- **Fail-closed gate, actually invoked.** New `agent-riggs gate` (exit 0 allow / 2 deny), `RiggsGate` MCP tool, gating of ratchet *tool* promotions (constraint promotions tighten and are never gated), and the LOOSEN recommendation published to `.kibitzer/state.json` (README's documented loop, now implemented). Denies on absent/tampered state, `min(t1,t5) < gate_threshold`, or a violation within `violation_holdoff_turns` — so a serious incident is sticky at the gate even though the short EWMA window recovers quickly (#3).
- **Trust policy is not subject-configurable.** `[trust]` is no longer read from `.riggs/config.toml`; it comes from shipped defaults plus `policy.toml` in the state directory.
- **Ingest hardening.** Idempotent (stable per-event UIDs recorded in the ledger — replay cannot re-count evidence); events applied in timestamp order across sources (fixes the seed/order mismatch, #3); malformed log lines skipped instead of aborting; ingest refuses to run on top of a tampered ledger.
- **Transitions correctness (#3).** `recommend_transition` takes `sustained_high_turns` (consecutive trailing high-trust turns, derived from the ledger) instead of total elapsed turns.
- **Docs (#3).** New `docs/trust-integrity.md` (threat model, mechanisms, and the explicit limits of the guarantee); enforcement language reconciled across README/tutorial/integration/the-ratchet/mcp/cli-reference/configuration.

### Tests

Reproduce-first regression tests that **fail on the previous code** and pass here:

- `tests/test_trust/test_integrity.py` — store deletion must not restore trust (previously read back max trust); a subject-forged max-trust store row must not be believed; self-reported success must not raise trust/EWMA (previously 0.26 → 1.00); replay idempotency; self-reported failures still count; observed accrual still works; subject config cannot weaken gate/scoring.
- `tests/test_trust/test_ledger.py` — chain verification: edit, truncation, key removal, forged head all read as tampered; absent reads as absent; key perms; out-of-tree location.
- `tests/test_trust/test_gate.py` / `test_gate_wiring.py` — pure gate decisions (absent/tampered/low/violation/allow) and the invoked paths (tool-promotion denial without verified trust, CLI exit codes, state.json publication).

Real filesystem-ownership separation isn't practical in CI: the ownership boundary is simulated via `AGENT_RIGGS_STATE_DIR`, and the pure unit tests of ledger verification + gate decisions are the always-run guards. Full suite: **107 passed** (was 72 passed + 2 date-rotted failures in `test_candidates.py`, also fixed here). `ruff check` clean. Manually smoke-tested end-to-end (init → gate deny → ingest observed evidence → gate allow → store deletion → trust persists → ledger tamper → gate/status/ingest all fail closed).

### Calibrated claims

**CONFIRMED closed** (by the passing repros): reset-by-deletion of the store, direct store edits, self-reported success inflation, replay double-counting, project-config policy weakening, and the fail-open/dead-code gate.

**PLAUSIBLE residual risk** (documented in `docs/trust-integrity.md`):
- The ownership boundary is only as strong as the deployment: within a single-user account with no write restrictions, a subject that can read the HMAC key or snapshot/restore the whole state directory defeats the chain. Deployments wanting a hard boundary should point `AGENT_RIGGS_STATE_DIR` at a directory outside the agent's write scope and run ingest/gate under a separate identity.
- blq's database is classified OBSERVED but lives in the project tree; a fabricated `.bird/blq.duckdb` can still manufacture observed successes where that file isn't protected.
- Whole-state rollback (ledger + head + key snapshot) is tamper-*evident* only via external anchoring, which is out of scope here.
- Concurrent ingests aren't locked; interleaving reads as tampered (fail closed, recoverable by resetting state to *low* trust).

Refs: GHSA-j5cw-vqqp-pmm5 (private), #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n